### PR TITLE
split Message into Notice and Op

### DIFF
--- a/components/watcher/src/watcher.rs
+++ b/components/watcher/src/watcher.rs
@@ -1,9 +1,11 @@
-use anyhow::{anyhow, Result};
 use std::{path::Path, sync::Arc};
 
+use anyhow::{anyhow, Result};
 use keri::{
+    actor::prelude::*,
     derivation::{basic::Basic, self_addressing::SelfAddressing, self_signing::SelfSigning},
     error::Error,
+    event_message::signed_event_message::{Notice, Op},
     oobi::{EndRole, LocationScheme, OobiManager, Scheme},
     prefix::{BasicPrefix, IdentifierPrefix},
     query::{
@@ -13,8 +15,6 @@ use keri::{
     signer::Signer,
     state::IdentifierState,
 };
-
-use keri::actor::prelude::*;
 
 pub struct WatcherData {
     pub prefix: BasicPrefix,
@@ -120,10 +120,21 @@ impl WatcherData {
     }
 
     // Returns messages if they can be returned immediately, i.e. for query message
-    pub fn process(&self, msg: Message) -> Result<Vec<Message>, Error> {
+    pub fn process(&self, msg: Message) -> Result<Option<Vec<Message>>, Error> {
+        let response = match msg.clone() {
+            Message::Op(op) => Some(self.process_op(op)?),
+            Message::Notice(notice) => {
+                process_notice(notice, &self.processor)?;
+                None
+            }
+        };
+        Ok(response)
+    }
+
+    fn process_op(&self, op: Op) -> Result<Vec<Message>, Error> {
         let mut responses = Vec::new();
-        match msg.clone() {
-            Message::Query(qry) => {
+        match op {
+            Op::Query(qry) => {
                 let response = process_signed_query(qry, &self.event_storage).unwrap();
                 match response {
                     ReplyType::Ksn(ksn) => {
@@ -135,24 +146,25 @@ impl WatcherData {
 
                         let signature =
                             SelfSigning::Ed25519Sha512.derive(self.signer.sign(&rpy.serialize()?)?);
-                        let reply = Message::Reply(SignedReply::new_nontrans(
+                        let reply = Message::Op(Op::Reply(SignedReply::new_nontrans(
                             rpy,
                             self.prefix.clone(),
                             signature,
-                        ));
+                        )));
                         responses.push(reply);
                     }
                     ReplyType::Kel(msgs) | ReplyType::Mbx(msgs) => responses.extend(msgs),
                 };
-                Ok(())
             }
-            _ => process_event(
-                msg,
-                &self.oobi_manager,
-                &self.processor,
-                &self.event_storage,
-            ),
-        }?;
+            Op::Reply(reply) => {
+                process_reply(
+                    reply,
+                    &self.oobi_manager,
+                    &self.processor,
+                    &self.event_storage,
+                )?;
+            }
+        }
         Ok(responses)
     }
 
@@ -162,6 +174,7 @@ impl WatcherData {
             .map(|message| self.process(message))
             // TODO: avoid unwrap
             .map(|d| d.unwrap())
+            .flatten()
             .flatten()
             .collect())
     }

--- a/components/watcher/src/watcher.rs
+++ b/components/watcher/src/watcher.rs
@@ -5,7 +5,7 @@ use keri::{
     actor::prelude::*,
     derivation::{basic::Basic, self_addressing::SelfAddressing, self_signing::SelfSigning},
     error::Error,
-    event_message::signed_event_message::{Notice, Op},
+    event_message::signed_event_message::Op,
     oobi::{EndRole, LocationScheme, OobiManager, Scheme},
     prefix::{BasicPrefix, IdentifierPrefix},
     query::{

--- a/components/watcher/src/watcher_listener.rs
+++ b/components/watcher/src/watcher_listener.rs
@@ -1,8 +1,8 @@
+use std::path::Path;
+
 use actix_web::{dev::Server, web, App, HttpServer};
 use anyhow::Result;
 use futures::future::join_all;
-use std::path::Path;
-
 use keri::{error::Error, oobi::LocationScheme, prefix::BasicPrefix};
 
 use crate::watcher::{Watcher, WatcherData};
@@ -75,7 +75,7 @@ pub mod http_handlers {
     use actix_web::{get, http::header::ContentType, post, web, HttpResponse, Responder};
     use keri::{
         derivation::{self_addressing::SelfAddressing, self_signing::SelfSigning},
-        event_message::signed_event_message::Message,
+        event_message::signed_event_message::{Message, Op},
         event_parsing::SignedEventData,
         oobi::{EndRole, LocationScheme, Role},
         prefix::{AttachedSignaturePrefix, IdentifierPrefix, Prefix},
@@ -149,7 +149,7 @@ pub mod http_handlers {
         let witness_id = IdentifierPrefix::Basic(witnesses[0].clone());
 
         // get witness address and send there query
-        let qry_str = Message::Query(signed_qry).to_cesr().unwrap();
+        let qry_str = Message::Op(Op::Query(signed_qry)).to_cesr().unwrap();
         println!(
             "\nSending query to {}: \n{}",
             witness_id.to_str(),

--- a/components/witness/src/witness.rs
+++ b/components/witness/src/witness.rs
@@ -8,7 +8,7 @@ use keri::{
     event_message::{
         event_msg_builder::ReceiptBuilder,
         key_event_message::KeyEvent,
-        signed_event_message::{Message, Op, SignedNontransferableReceipt},
+        signed_event_message::{Message, Notice, Op, SignedNontransferableReceipt},
     },
     oobi::{LocationScheme, OobiManager},
     prefix::{BasicPrefix, IdentifierPrefix},
@@ -200,7 +200,11 @@ impl Witness {
         Ok(response)
     }
 
-    fn process_op(&self, op: Op) -> Result<Vec<Message>, Error> {
+    pub fn process_notice(&self, notice: Notice) -> Result<(), Error> {
+        self.processor.process_notice(&notice)
+    }
+
+    pub fn process_op(&self, op: Op) -> Result<Vec<Message>, Error> {
         let mut responses = Vec::new();
 
         match op {

--- a/components/witness/src/witness.rs
+++ b/components/witness/src/witness.rs
@@ -1,18 +1,16 @@
 use std::{path::Path, sync::Arc};
 
-use keri::actor::prelude::*;
-use keri::actor::process_signed_query;
-use keri::oobi::OobiManager;
 use keri::{
+    actor::{prelude::*, process_reply, process_signed_query},
     derivation::{basic::Basic, self_addressing::SelfAddressing, self_signing::SelfSigning},
     error::Error,
     event::EventMessage,
     event_message::{
         event_msg_builder::ReceiptBuilder,
         key_event_message::KeyEvent,
-        signed_event_message::{Message, SignedNontransferableReceipt},
+        signed_event_message::{Message, Op, SignedNontransferableReceipt},
     },
-    oobi::LocationScheme,
+    oobi::{LocationScheme, OobiManager},
     prefix::{BasicPrefix, IdentifierPrefix},
     processor::notification::{Notification, NotificationBus, Notifier},
     query::{
@@ -190,10 +188,23 @@ impl Witness {
     }
 
     // Returns messages if they can be returned immediately, i.e. for query message
-    pub fn process(&self, msg: Message) -> Result<Vec<Message>, Error> {
+    pub fn process(&self, msg: Message) -> Result<Option<Vec<Message>>, Error> {
+        let response = match msg.clone() {
+            Message::Op(op) => Some(self.process_op(op)?),
+            Message::Notice(notice) => {
+                self.processor.process_notice(&notice)?;
+                None
+            }
+        };
+
+        Ok(response)
+    }
+
+    fn process_op(&self, op: Op) -> Result<Vec<Message>, Error> {
         let mut responses = Vec::new();
-        match msg.clone() {
-            Message::Query(qry) => {
+
+        match op {
+            Op::Query(qry) => {
                 let response = process_signed_query(qry, &self.event_storage).unwrap();
                 match response {
                     ReplyType::Ksn(ksn) => {
@@ -205,24 +216,26 @@ impl Witness {
 
                         let signature =
                             SelfSigning::Ed25519Sha512.derive(self.signer.sign(&rpy.serialize()?)?);
-                        let reply = Message::Reply(SignedReply::new_nontrans(
+                        let reply = Message::Op(Op::Reply(SignedReply::new_nontrans(
                             rpy,
                             self.prefix.clone(),
                             signature,
-                        ));
+                        )));
                         responses.push(reply);
                     }
                     ReplyType::Kel(msgs) | ReplyType::Mbx(msgs) => responses.extend(msgs),
                 };
-                Ok(())
             }
-            _ => process_event(
-                msg,
-                &self.oobi_manager,
-                &self.processor,
-                &self.event_storage,
-            ),
-        }?;
+            Op::Reply(rpy) => {
+                process_reply(
+                    rpy,
+                    &self.oobi_manager,
+                    &self.processor,
+                    &self.event_storage,
+                )?;
+            }
+        }
+
         Ok(responses)
     }
 
@@ -232,6 +245,7 @@ impl Witness {
             .map(|message| self.process(message))
             // TODO: avoid unwrap
             .map(|d| d.unwrap())
+            .flatten()
             .flatten()
             .collect())
     }

--- a/keriox_core/src/actor/mod.rs
+++ b/keriox_core/src/actor/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     query::{
         key_state_notice::KeyStateNotice,
         query_event::{Query, SignedQuery},
-        reply_event::{self, ReplyRoute, SignedReply},
+        reply_event::{ReplyRoute, SignedReply},
         ReplyType,
     },
 };

--- a/keriox_core/src/event/sections/key_config.rs
+++ b/keriox_core/src/event/sections/key_config.rs
@@ -1,12 +1,11 @@
 use serde::{Deserialize, Serialize};
 
+use super::threshold::SignatureThreshold;
 use crate::{
     derivation::self_addressing::SelfAddressing,
     error::Error,
     prefix::{AttachedSignaturePrefix, BasicPrefix, Prefix, SelfAddressingPrefix},
 };
-
-use super::threshold::SignatureThreshold;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
 pub struct NextKeysData {
@@ -178,10 +177,13 @@ fn test_next_commitment() {
 
 #[test]
 fn test_threshold() -> Result<(), Error> {
-    use crate::derivation::{basic::Basic, self_signing::SelfSigning};
-    use crate::keys::{PrivateKey, PublicKey};
     use ed25519_dalek::Keypair;
     use rand::rngs::OsRng;
+
+    use crate::{
+        derivation::{basic::Basic, self_signing::SelfSigning},
+        keys::{PrivateKey, PublicKey},
+    };
 
     let (pub_keys, priv_keys): (Vec<BasicPrefix>, Vec<PrivateKey>) = [0, 1, 2]
         .iter()
@@ -261,10 +263,13 @@ fn test_threshold() -> Result<(), Error> {
 
 #[test]
 fn test_verify() -> Result<(), Error> {
-    use crate::event::event_data::EventData;
-    use crate::event_message::signed_event_message::Message;
-    use crate::event_parsing::message::signed_message;
     use std::convert::TryFrom;
+
+    use crate::{
+        event::event_data::EventData,
+        event_message::signed_event_message::{Message, Notice},
+        event_parsing::message::signed_message,
+    };
 
     // test data taken from keripy
     // (keripy/tests/core/test_weighted_threshold.py::test_weighted)
@@ -272,7 +277,7 @@ fn test_verify() -> Result<(), Error> {
     let parsed = signed_message(ev).unwrap().1;
     let signed_msg = Message::try_from(parsed).unwrap();
     match signed_msg {
-        Message::Event(ref e) => {
+        Message::Notice(Notice::Event(ref e)) => {
             if let EventData::Icp(icp) = e.to_owned().event_message.event.get_event_data() {
                 let kc = icp.key_config;
                 let msg = e.event_message.serialize()?;
@@ -286,7 +291,7 @@ fn test_verify() -> Result<(), Error> {
     let parsed = signed_message(ev).unwrap().1;
     let signed_msg = Message::try_from(parsed).unwrap();
     match signed_msg {
-        Message::Event(ref e) => {
+        Message::Notice(Notice::Event(ref e)) => {
             if let EventData::Icp(icp) = e.to_owned().event_message.event.get_event_data() {
                 let kc = icp.key_config;
                 let msg = e.event_message.serialize()?;

--- a/keriox_core/src/oobi/mod.rs
+++ b/keriox_core/src/oobi/mod.rs
@@ -7,7 +7,7 @@ use url::Url;
 use self::error::Error as OobiError;
 use crate::{
     error::Error,
-    event_message::signed_event_message::Message,
+    event_message::signed_event_message::{Message, Op},
     event_parsing::message::signed_event_stream,
     prefix::IdentifierPrefix,
     query::reply_event::{bada_logic, ReplyEvent, ReplyRoute, SignedReply},
@@ -120,7 +120,7 @@ impl OobiManager {
             .try_for_each(|sed| -> Result<_, Error> {
                 let msg = Message::try_from(sed).unwrap();
                 match msg {
-                    Message::Reply(oobi_rpy) => {
+                    Message::Op(Op::Reply(oobi_rpy)) => {
                         self.check_oobi_reply(&oobi_rpy)?;
                         self.store.save_oobi(&oobi_rpy)?;
                         Ok(())

--- a/keriox_core/src/processor/mod.rs
+++ b/keriox_core/src/processor/mod.rs
@@ -10,26 +10,31 @@ pub mod notification;
 mod tests;
 pub mod validator;
 
+use self::{
+    notification::{JustNotification, Notification, NotificationBus, Notifier},
+    validator::EventValidator,
+};
 use crate::{
     database::sled::SledEventDatabase,
     error::Error,
     event::{receipt::Receipt, SerializationFormats},
     event_message::signed_event_message::{
-        Message, SignedEventMessage, SignedNontransferableReceipt, TimestampedSignedEventMessage,
+        Notice, SignedEventMessage, SignedNontransferableReceipt,
+        TimestampedSignedEventMessage,
     },
     prefix::IdentifierPrefix,
-    query::reply_event::ReplyRoute,
+    query::reply_event::{ReplyRoute, SignedReply},
     state::IdentifierState,
-};
-
-use self::{
-    notification::{JustNotification, Notification, NotificationBus, Notifier},
-    validator::EventValidator,
 };
 
 pub trait Processor {
     fn new(db_path: Arc<SledEventDatabase>) -> Self;
-    fn process(&self, message: &Message) -> Result<(), Error>;
+
+    fn process_notice(&self, notice: &Notice) -> Result<(), Error>;
+
+    #[cfg(feature = "query")]
+    fn process_op_reply(&self, reply: &SignedReply) -> Result<(), Error>;
+
     fn register_observer(&mut self, observer: Arc<dyn Notifier + Send + Sync>)
         -> Result<(), Error>;
 }
@@ -64,16 +69,28 @@ impl EventProcessor {
         Ok(())
     }
 
-    /// Process
-    ///
-    /// Process a deserialized KERI message
-    /// Update database based on event validation result.
-    pub fn process<F>(&self, message: &Message, processing_strategy: F) -> Result<(), Error>
+    #[cfg(feature = "query")]
+    pub fn process_op_reply(&self, rpy: &SignedReply) -> Result<(), Error> {
+        match rpy.reply.get_route() {
+            ReplyRoute::Ksn(_, _) => match self.validator.process_signed_ksn_reply(&rpy) {
+                Ok(_) => self
+                    .db
+                    .update_accepted_reply(rpy.clone(), &rpy.reply.get_prefix()),
+                Err(Error::EventOutOfOrderError) => self
+                    .publisher
+                    .notify(&Notification::KsnOutOfOrder(rpy.clone())),
+                Err(anything) => Err(anything),
+            },
+            _ => Ok(()),
+        }
+    }
+
+    pub fn process_notice<F>(&self, notice: &Notice, processing_strategy: F) -> Result<(), Error>
     where
         F: Fn(Arc<SledEventDatabase>, &NotificationBus, SignedEventMessage) -> Result<(), Error>,
     {
-        match &message {
-            Message::Event(signed_event) => {
+        match notice {
+            Notice::Event(signed_event) => {
                 processing_strategy(self.db.clone(), &self.publisher, signed_event.clone())?;
                 // check if receipts are attached
                 if let Some(witness_receipts) = &signed_event.witness_receipts {
@@ -90,15 +107,15 @@ impl EventProcessor {
                         None,
                         Some(witness_receipts.clone()),
                     );
-                    self.process(
-                        &Message::NontransferableRct(signed_receipt),
+                    self.process_notice(
+                        &Notice::NontransferableRct(signed_receipt),
                         processing_strategy,
                     )
                 } else {
                     Ok(())
                 }
             }
-            Message::NontransferableRct(rct) => {
+            Notice::NontransferableRct(rct) => {
                 let id = &rct.body.event.prefix;
                 match self.validator.validate_witness_receipt(&rct) {
                     Ok(_) => {
@@ -111,37 +128,16 @@ impl EventProcessor {
                     Err(e) => Err(e),
                 }
             }
-            Message::TransferableRct(vrc) => {
-                match self.validator.validate_validator_receipt(&vrc) {
-                    Ok(_) => {
-                        self.db.add_receipt_t(vrc.clone(), &vrc.body.event.prefix)?;
-                        self.publisher.notify(&Notification::ReceiptAccepted)
-                    }
-                    Err(Error::MissingEvent) | Err(Error::EventOutOfOrderError) => self
-                        .publisher
-                        .notify(&Notification::TransReceiptOutOfOrder(vrc.clone())),
-                    Err(e) => Err(e),
+            Notice::TransferableRct(vrc) => match self.validator.validate_validator_receipt(&vrc) {
+                Ok(_) => {
+                    self.db.add_receipt_t(vrc.clone(), &vrc.body.event.prefix)?;
+                    self.publisher.notify(&Notification::ReceiptAccepted)
                 }
-            }
-            #[cfg(feature = "query")]
-            Message::Reply(rpy) => match rpy.reply.get_route() {
-                ReplyRoute::Ksn(_, _) => match self.validator.process_signed_ksn_reply(&rpy) {
-                    Ok(_) => self
-                        .db
-                        .update_accepted_reply(rpy.clone(), &rpy.reply.get_prefix()),
-                    Err(Error::EventOutOfOrderError) => self
-                        .publisher
-                        .notify(&Notification::KsnOutOfOrder(rpy.clone())),
-                    Err(anything) => Err(anything),
-                },
-                _ => Ok(()),
+                Err(Error::MissingEvent) | Err(Error::EventOutOfOrderError) => self
+                    .publisher
+                    .notify(&Notification::TransReceiptOutOfOrder(vrc.clone())),
+                Err(e) => Err(e),
             },
-            #[cfg(feature = "query")]
-            Message::Query(_) => {
-                // TODO should do nothing?
-                // It doesn't update database
-                Ok(())
-            }
         }
     }
 }

--- a/keriox_core/src/processor/mod.rs
+++ b/keriox_core/src/processor/mod.rs
@@ -19,8 +19,7 @@ use crate::{
     error::Error,
     event::{receipt::Receipt, SerializationFormats},
     event_message::signed_event_message::{
-        Notice, SignedEventMessage, SignedNontransferableReceipt,
-        TimestampedSignedEventMessage,
+        Notice, SignedEventMessage, SignedNontransferableReceipt, TimestampedSignedEventMessage,
     },
     prefix::IdentifierPrefix,
     query::reply_event::{ReplyRoute, SignedReply},
@@ -37,6 +36,21 @@ pub trait Processor {
 
     fn register_observer(&mut self, observer: Arc<dyn Notifier + Send + Sync>)
         -> Result<(), Error>;
+
+    fn process(
+        &self,
+        msg: &crate::event_message::signed_event_message::Message,
+    ) -> Result<(), Error> {
+        use crate::event_message::signed_event_message::{Message, Op};
+
+        match msg {
+            Message::Notice(notice) => self.process_notice(notice),
+            Message::Op(op) => match op {
+                Op::Query(_query) => panic!("processor can't handle query op"),
+                Op::Reply(reply) => self.process_op_reply(reply),
+            },
+        }
+    }
 }
 
 pub struct EventProcessor {

--- a/keriox_core/tests/test_processing.rs
+++ b/keriox_core/tests/test_processing.rs
@@ -1,9 +1,10 @@
-use keri::actor::prelude::*;
 use std::sync::Arc;
 
 use keri::{
-    database::sled::SledEventDatabase, error::Error, processor::event_storage::EventStorage,
+    actor::prelude::*, database::sled::SledEventDatabase, error::Error,
+    event_message::signed_event_message::Op, processor::event_storage::EventStorage,
 };
+
 #[test]
 pub fn test_ksn_query() -> Result<(), Error> {
     use keri::event_message::signed_event_message::Message;
@@ -32,7 +33,7 @@ pub fn test_ksn_query() -> Result<(), Error> {
     let qry_str = r#"{"v":"KERI10JSON000104_","t":"qry","d":"ErXRrwRbUFylKDiuOp8a1wO2XPAY4KiMX4TzYWZ1iAGE","dt":"2022-03-21T11:42:58.123955+00:00","r":"ksn","rr":"","q":{"s":0,"i":"E6OK2wFYp6x0Jx48xX0GCTwAzJUTWtYEvJSykVhtAnaM","src":"BGKVzj4ve0VSd8z_AmvhLg4lqcC_9WYX90k03q-R_Ydo"}}-VAj-HABE6OK2wFYp6x0Jx48xX0GCTwAzJUTWtYEvJSykVhtAnaM-AABAAk-Hyv8gpUZNpPYDGJc5F5vrLNWlGM26523Sgb6tKN1CtP4QxUjEApJCRxfm9TN8oW2nQ40QVM_IuZlrly1eLBA"#;
 
     let parsed = parse_event_stream(qry_str.as_bytes()).unwrap();
-    if let Message::Query(signed_query) = parsed.get(0).unwrap().clone() {
+    if let Message::Op(Op::Query(signed_query)) = parsed.get(0).unwrap().clone() {
         let r = process_signed_query(signed_query, &storage)?;
 
         if let ReplyType::Ksn(ksn) = r {
@@ -70,7 +71,7 @@ fn processs_oobi() -> Result<(), Error> {
     );
     let events = parse_event_stream(oobi_rpy.as_bytes()).unwrap();
     for event in events {
-        let res = process_event(event, &oobi_manager, &processor, &storage);
+        let res = process_message(event, &oobi_manager, &processor, &storage);
         assert!(res.is_ok())
     }
     Ok(())


### PR DESCRIPTION
Before:
```rs
enum Message {
    Event(SignedEventMessage),
    NontransferableRct(SignedNontransferableReceipt),
    TransferableRct(SignedTransferableReceipt),
    Reply(SignedReply),
    Query(SignedQuery),
}
```

After:
```rs
enum Message {
    Notice(Notice),
    Op(Op),
}

enum Notice {
    Event(SignedEventMessage),
    NontransferableRct(SignedNontransferableReceipt),
    TransferableRct(SignedTransferableReceipt),
}

enum Op {
    Reply(SignedReply),
    Query(SignedQuery),
}
```