### PR TITLE
feat: register endpoint

### DIFF
--- a/components/watcher/src/watcher_listener.rs
+++ b/components/watcher/src/watcher_listener.rs
@@ -47,7 +47,6 @@ impl WatcherListener {
                 .service(http_handlers::resolve_oobi)
                 .service(http_handlers::process_notice)
                 .service(http_handlers::process_op)
-            // .service(resolve)
         })
         .bind((host, port))
         .unwrap()
@@ -110,12 +109,12 @@ pub mod http_handlers {
         data: web::Data<Watcher>,
     ) -> Result<impl Responder, ApiError> {
         println!(
-            "\nGot events to process: \n{}",
+            "\nGot queries to process: \n{}",
             String::from_utf8_lossy(&body)
         );
         let resp = data
             .0
-            .parse_and_process_ops(&body)
+            .parse_and_process_queries(&body)
             .await?
             .iter()
             .map(|msg| msg.to_string())
@@ -124,6 +123,23 @@ pub mod http_handlers {
         Ok(HttpResponse::Ok()
             .content_type(ContentType::plaintext())
             .body(resp))
+    }
+
+    #[post("/discover")]
+    async fn process_reply(
+        body: web::Bytes,
+        data: web::Data<Watcher>,
+    ) -> Result<impl Responder, ApiError> {
+        println!(
+            "\nGot replies to process: \n{}",
+            String::from_utf8_lossy(&body)
+        );
+
+        data.0.parse_and_process_replies(&body)?;
+
+        Ok(HttpResponse::Ok()
+            .content_type(ContentType::plaintext())
+            .body(()))
     }
 
     #[post("/resolve")]

--- a/components/watcher/src/watcher_listener.rs
+++ b/components/watcher/src/watcher_listener.rs
@@ -125,7 +125,7 @@ pub mod http_handlers {
             .body(resp))
     }
 
-    #[post("/discover")]
+    #[post("/register")]
     async fn process_reply(
         body: web::Bytes,
         data: web::Data<Watcher>,

--- a/components/witness/src/witness_listener.rs
+++ b/components/witness/src/witness_listener.rs
@@ -166,7 +166,7 @@ pub mod http_handlers {
             .body(resp))
     }
 
-    #[post("/discover")]
+    #[post("/register")]
     pub async fn process_reply(
         post_data: String,
         data: web::Data<Witness>,

--- a/components/witness/src/witness_listener.rs
+++ b/components/witness/src/witness_listener.rs
@@ -46,8 +46,8 @@ impl WitnessListener {
                 .service(http_handlers::get_eid_oobi)
                 .service(http_handlers::get_cid_oobi)
                 .service(http_handlers::process_notice)
-                .service(http_handlers::process_op)
-            // .service(resolve)
+                .service(http_handlers::process_query)
+                .service(http_handlers::process_reply)
         })
         .bind((host, port))
         .unwrap()
@@ -149,13 +149,13 @@ pub mod http_handlers {
     }
 
     #[post("/query")]
-    pub async fn process_op(
+    pub async fn process_query(
         post_data: String,
         data: web::Data<Witness>,
     ) -> Result<impl Responder, ApiError> {
-        println!("\nGot op to process: \n{}", post_data);
+        println!("\nGot query to process: \n{}", post_data);
         let resp = data
-            .parse_and_process_ops(post_data.as_bytes())?
+            .parse_and_process_queries(post_data.as_bytes())?
             .iter()
             .map(|msg| msg.to_string())
             .collect::<Vec<_>>()
@@ -163,6 +163,19 @@ pub mod http_handlers {
         Ok(HttpResponse::Ok()
             .content_type(ContentType::plaintext())
             .body(resp))
+    }
+
+    #[post("/discover")]
+    pub async fn process_reply(
+        post_data: String,
+        data: web::Data<Witness>,
+    ) -> Result<impl Responder, ApiError> {
+        println!("\nGot reply to process: \n{}", post_data);
+        data.parse_and_process_replies(post_data.as_bytes())?;
+
+        Ok(HttpResponse::Ok()
+            .content_type(ContentType::plaintext())
+            .body(()))
     }
 
     #[derive(Debug, Display, Error, From)]

--- a/components/witness/src/witness_listener.rs
+++ b/components/witness/src/witness_listener.rs
@@ -48,6 +48,7 @@ impl WitnessListener {
                 .service(http_handlers::process_notice)
                 .service(http_handlers::process_query)
                 .service(http_handlers::process_reply)
+                .service(http_handlers::process_exchange)
         })
         .bind((host, port))
         .unwrap()
@@ -172,6 +173,19 @@ pub mod http_handlers {
     ) -> Result<impl Responder, ApiError> {
         println!("\nGot reply to process: \n{}", post_data);
         data.parse_and_process_replies(post_data.as_bytes())?;
+
+        Ok(HttpResponse::Ok()
+            .content_type(ContentType::plaintext())
+            .body(()))
+    }
+
+    #[post("/forward")]
+    pub async fn process_exchange(
+        post_data: String,
+        data: web::Data<Witness>,
+    ) -> Result<impl Responder, ApiError> {
+        println!("\nGot exchange to process: \n{}", post_data);
+        data.parse_and_process_exchanges(post_data.as_bytes())?;
 
         Ok(HttpResponse::Ok()
             .content_type(ContentType::plaintext())

--- a/keriox_core/src/actor/mod.rs
+++ b/keriox_core/src/actor/mod.rs
@@ -50,6 +50,24 @@ pub fn parse_op_stream(stream: &[u8]) -> Result<Vec<Op>, Error> {
     ops.into_iter().map(Op::try_from).collect()
 }
 
+#[cfg(any(feature = "query", feature = "oobi"))]
+pub fn parse_query_stream(stream: &[u8]) -> Result<Vec<SignedQuery>, Error> {
+    use crate::event_parsing::message::signed_op_stream;
+
+    let (_rest, queries) =
+        signed_op_stream(stream).map_err(|e| Error::DeserializeError(e.to_string()))?;
+    queries.into_iter().map(SignedQuery::try_from).collect()
+}
+
+#[cfg(any(feature = "query", feature = "oobi"))]
+pub fn parse_reply_stream(stream: &[u8]) -> Result<Vec<SignedReply>, Error> {
+    use crate::event_parsing::message::signed_op_stream;
+
+    let (_rest, replies) =
+        signed_op_stream(stream).map_err(|e| Error::DeserializeError(e.to_string()))?;
+    replies.into_iter().map(SignedReply::try_from).collect()
+}
+
 pub fn process_message<P: Processor>(
     msg: Message,
     oobi_manager: &OobiManager,

--- a/keriox_core/src/actor/mod.rs
+++ b/keriox_core/src/actor/mod.rs
@@ -68,6 +68,15 @@ pub fn parse_reply_stream(stream: &[u8]) -> Result<Vec<SignedReply>, Error> {
     replies.into_iter().map(SignedReply::try_from).collect()
 }
 
+#[cfg(any(feature = "query", feature = "oobi"))]
+pub fn parse_exchange_stream(stream: &[u8]) -> Result<Vec<SignedExchange>, Error> {
+    use crate::event_parsing::message::signed_op_stream;
+
+    let (_rest, exchanges) =
+        signed_op_stream(stream).map_err(|e| Error::DeserializeError(e.to_string()))?;
+    exchanges.into_iter().map(SignedExchange::try_from).collect()
+}
+
 pub fn process_message<P: Processor>(
     msg: Message,
     oobi_manager: &OobiManager,

--- a/keriox_core/src/actor/simple_controller.rs
+++ b/keriox_core/src/actor/simple_controller.rs
@@ -472,7 +472,7 @@ impl<K: KeyManager> SimpleController<K> {
         })
     }
 
-    pub fn query_mailbox(&self, witness: &BasicPrefix) -> Op {
+    pub fn query_mailbox(&self, witness: &BasicPrefix) -> SignedQuery {
         let qry_msg = QueryEvent::new_query(
             QueryRoute::Mbx {
                 args: QueryArgsMbx {
@@ -505,11 +505,7 @@ impl<K: KeyManager> SimpleController<K> {
             signature,
             0,
         )];
-        let mbx_msg = Op::Query(SignedQuery::new(
-            qry_msg,
-            self.prefix.clone().clone(),
-            signatures,
-        ));
+        let mbx_msg = SignedQuery::new(qry_msg, self.prefix.clone().clone(), signatures);
         mbx_msg
     }
 

--- a/keriox_core/src/event_parsing/mod.rs
+++ b/keriox_core/src/event_parsing/mod.rs
@@ -371,6 +371,19 @@ impl TryFrom<SignedEventData> for SignedReply {
     }
 }
 
+impl TryFrom<SignedEventData> for SignedExchange {
+    type Error = Error;
+
+    fn try_from(value: SignedEventData) -> Result<Self, Self::Error> {
+        match Op::try_from(value)? {
+            Op::Exchange(exn) => Ok(exn),
+            _ => Err(Error::SemanticError(
+                "Cannot convert SignedEventData to SignedExchange".to_string(),
+            )),
+        }
+    }
+}
+
 #[cfg(any(feature = "query", feature = "oobi"))]
 fn signed_reply(rpy: ReplyEvent, mut attachments: Vec<Attachment>) -> Result<Op, Error> {
     match attachments

--- a/keriox_tests/tests/watcher.rs
+++ b/keriox_tests/tests/watcher.rs
@@ -10,7 +10,7 @@ use keri::{
     error::Error,
     event_message::signed_event_message::{Message, Notice, Op},
     oobi::{LocationScheme, Role},
-    prefix::{IdentifierPrefix, Prefix},
+    prefix::IdentifierPrefix,
     query::reply_event::SignedReply,
 };
 use keri_transport::{Transport, TransportError};
@@ -150,7 +150,6 @@ pub fn watcher_forward_ksn() -> Result<(), Error> {
                                     Ok(vec![])
                                 }
                             }
-                            _ => panic!("Unexpected message"),
                         }
                     }
                 }),
@@ -202,8 +201,7 @@ pub fn watcher_forward_ksn() -> Result<(), Error> {
                 .unwrap(),
         ),
     );
-    // TODO: wrap in Message:Op and send to reply/ endpoint
-    watcher.oobi_manager.process_oobi(&witness_oobi).unwrap();
+    watcher.process_reply(witness_oobi).unwrap();
 
     // Send query again
     let result = futures::executor::block_on(watcher.process_op(query));

--- a/support/transport/src/default.rs
+++ b/support/transport/src/default.rs
@@ -19,15 +19,25 @@ impl Transport for DefaultTransport {
         msg: Message,
     ) -> Result<Vec<Message>, TransportError> {
         let url = match loc.scheme {
-            Scheme::Http => match msg {
+            Scheme::Http => match &msg {
                 Message::Notice(_) => {
                     // {url}/process
                     loc.url.join("process").unwrap()
                 }
-                Message::Op(_) => {
-                    // {url}/query
-                    loc.url.join("query").unwrap()
-                }
+                Message::Op(op) => match op {
+                    Op::Query(_) => {
+                        // {url}/query
+                        loc.url.join("query").unwrap()
+                    }
+                    Op::Reply(_) => {
+                        // {url}/register
+                        loc.url.join("register").unwrap()
+                    }
+                    Op::Exchange(_) => {
+                        // {url}/forward
+                        loc.url.join("forward").unwrap()
+                    }
+                },
             },
             Scheme::Tcp => todo!(),
         };


### PR DESCRIPTION
Add ~~`/discover`~~ `/register` endpoint to Witness and Watcher. It calls `parse_and_process_replies`. `/query` now only handles queries.