### PR TITLE
Unify query mailbox

### DIFF
--- a/components/controller/src/identifier_controller.rs
+++ b/components/controller/src/identifier_controller.rs
@@ -40,7 +40,6 @@ use super::mailbox_updating::ActionRequired;
 
 pub struct IdentifierController {
     pub id: IdentifierPrefix,
-    // pub groups: Vec<IdentifierPrefix>,
     pub source: Arc<Controller>,
     last_asked_index: MailboxReminder,
     last_asked_groups_index: MailboxReminder,

--- a/components/controller/src/identifier_controller.rs
+++ b/components/controller/src/identifier_controller.rs
@@ -337,7 +337,7 @@ impl IdentifierController {
         &mut self,
         group_event: &[u8],
         sig: SelfSigningPrefix,
-        exchanges: Vec<(&[u8], SelfSigningPrefix)>,
+        exchanges: Vec<(Vec<u8>, SelfSigningPrefix)>,
     ) -> Result<IdentifierPrefix, ControllerError> {
         // Join icp event with signature
         let (_, key_event) = key_event_message(&group_event).unwrap();
@@ -383,7 +383,7 @@ impl IdentifierController {
         let material_path = MaterialPath::to_path("-a".into());
         let attached_sig = sigs;
         for (exn, signature) in exchanges {
-            let (_, parsed_exn) = exchange_message(exn).unwrap();
+            let (_, parsed_exn) = exchange_message(&exn).unwrap();
             let exn = if let EventType::Exn(exn) = parsed_exn {
                 exn
             } else {

--- a/components/controller/src/identifier_controller.rs
+++ b/components/controller/src/identifier_controller.rs
@@ -516,7 +516,7 @@ impl IdentifierController {
                 index: 0,
                 signature: sig,
             }];
-            let (receipient, from_who, about_who) = match &qry.event.content.data.route {
+            let (receipient, about_who, from_who) = match &qry.event.content.data.route {
                 QueryRoute::Log {
                     reply_route: _,
                     args,

--- a/components/controller/src/mailbox_updating.rs
+++ b/components/controller/src/mailbox_updating.rs
@@ -79,16 +79,17 @@ impl IdentifierController {
 
     pub async fn process_groups_mailbox(
         &self,
+        groups: Vec<IdentifierPrefix>,
         mb: &MailboxResponse,
         from_index: &MailboxReminder,
     ) -> Result<Vec<ActionRequired>, ControllerError> {
-        Ok(futures::stream::iter(&self.groups)
+        Ok(futures::stream::iter(&groups)
             .then(|group_id| self.process_group_mailbox(mb, group_id, from_index))
             .try_concat()
             .await?)
     }
 
-    async fn process_group_mailbox(
+    pub async fn process_group_mailbox(
         &self,
         mb: &MailboxResponse,
         group_id: &IdentifierPrefix,

--- a/components/controller/src/mailbox_updating.rs
+++ b/components/controller/src/mailbox_updating.rs
@@ -168,7 +168,9 @@ impl IdentifierController {
 
         match to_publish {
             Some(to_publish) => {
-                let witnesses = self.source.get_current_witness_list(&id)?;
+                let witnesses = self
+                    .source
+                    .get_witnesses_at_event(&to_publish.event_message)?;
                 self.source.publish(&witnesses, &to_publish).await
             }
             None => Ok(()),

--- a/components/controller/src/test.rs
+++ b/components/controller/src/test.rs
@@ -58,13 +58,11 @@ async fn test_group_incept() -> Result<(), ControllerError> {
     // Group initiator needs to use `finalize_group_incept` instead of just
     // `finalize_event`, to send multisig request to other group participants.
     // Identifier who get this request from mailbox, can use just `finalize_event`
-    let group_id = identifier1
-        .finalize_group_incept(
-            group_inception.as_bytes(),
-            signature_icp,
-            vec![(exn_messages[0].as_bytes(), signature_exn)],
-        )
-        .await?;
+    let group_id = identifier1.finalize_group_incept(
+        group_inception.as_bytes(),
+        signature_icp,
+        vec![(exn_messages[0].as_bytes().to_vec(), signature_exn)],
+    ).await?;
 
     let kel = controller
         .storage
@@ -190,7 +188,7 @@ async fn test_delegated_incept() -> Result<(), ControllerError> {
         .finalize_group_incept(
             delegated_inception.as_bytes(),
             signature_icp.clone(),
-            vec![(exn_messages[0].as_bytes(), signature_exn.clone())],
+            vec![(exn_messages[0].as_bytes().to_vec(), signature_exn.clone())],
         )
         .await?;
 

--- a/components/controller/src/test.rs
+++ b/components/controller/src/test.rs
@@ -136,8 +136,7 @@ async fn test_delegated_incept() -> Result<(), ControllerError> {
         IdentifierController::new(incepted_identifier, controller.clone())
     };
     // Quering mailbox to get receipts
-    println!("Querying own mailbox to get receipts");
-    let query = identifier1.query_own_mailbox(&[witness_id_basic.clone()])?;
+    let query = identifier1.query_mailbox(&identifier1.id, &[witness_id_basic.clone()])?;
 
     for qry in query {
         let signature = SelfSigning::Ed25519Sha512.derive(km1.sign(&qry.serialize()?)?);
@@ -162,7 +161,7 @@ async fn test_delegated_incept() -> Result<(), ControllerError> {
     };
 
     // Quering mailbox to get receipts
-    let query = delegator.query_own_mailbox(&[witness_id_basic.clone()])?;
+    let query = delegator.query_mailbox(&delegator.id, &[witness_id_basic.clone()])?;
 
     for qry in query {
         let signature = SelfSigning::Ed25519Sha512.derive(km2.sign(&qry.serialize()?)?);
@@ -196,7 +195,7 @@ async fn test_delegated_incept() -> Result<(), ControllerError> {
         .await?;
 
     // Quering mailbox to get receipts
-    let query = delegator.query_own_mailbox(&[witness_id_basic.clone()])?;
+    let query = delegator.query_mailbox(&delegator.id, &[witness_id_basic.clone()])?;
 
     for qry in query {
         let signature = SelfSigning::Ed25519Sha512.derive(km2.sign(&qry.serialize()?)?);
@@ -218,7 +217,7 @@ async fn test_delegated_incept() -> Result<(), ControllerError> {
     assert!(kel.is_none());
 
     // Delegator asks about his mailbox to get delegated event.
-    let query = delegator.query_own_mailbox(&[witness_id_basic.clone()])?;
+    let query = delegator.query_mailbox(&delegator.id, &[witness_id_basic.clone()])?;
 
     for qry in query {
         let signature = SelfSigning::Ed25519Sha512.derive(km2.sign(&qry.serialize()?)?);
@@ -241,7 +240,7 @@ async fn test_delegated_incept() -> Result<(), ControllerError> {
                     .await?;
 
                 // Query for receipts
-                let query = delegator.query_own_mailbox(&[witness_id_basic.clone()])?;
+                let query = delegator.query_mailbox(&delegator.id, &[witness_id_basic.clone()])?;
 
                 for qry in query {
                     let signature = SelfSigning::Ed25519Sha512.derive(km2.sign(&qry.serialize()?)?);
@@ -271,7 +270,8 @@ async fn test_delegated_incept() -> Result<(), ControllerError> {
     controller.process(&Message::Notice(delegators_kel[0].clone()))?; // icp
     controller.process(&Message::Notice(delegators_kel[1].clone()))?; // receipt
 
-    let query = identifier1.query_group_mailbox(&[witness_id_basic.clone()])?;
+    // Ask about delegated identifier mailbox
+    let query = identifier1.query_mailbox(&delegate_id, &[witness_id_basic.clone()])?;
 
     for qry in query {
         let signature = SelfSigning::Ed25519Sha512.derive(km1.sign(&qry.serialize()?)?);
@@ -289,7 +289,7 @@ async fn test_delegated_incept() -> Result<(), ControllerError> {
     assert_eq!(state, None);
 
     // Get mailbox for receipts.
-    let query = identifier1.query_group_mailbox(&[witness_id_basic.clone()])?;
+    let query = identifier1.query_mailbox(&delegate_id, &[witness_id_basic.clone()])?;
 
     for qry in query {
         let signature = SelfSigning::Ed25519Sha512.derive(km1.sign(&qry.serialize()?)?);

--- a/keriox_core/src/actor/simple_controller.rs
+++ b/keriox_core/src/actor/simple_controller.rs
@@ -441,11 +441,18 @@ impl<K: KeyManager> SimpleController<K> {
                 .public_keys
                 .iter()
                 .position(|pk| pk == own_pk),
-            EventData::Rot(rot) => rot
-                .key_config
-                .public_keys
-                .iter()
-                .position(|pk| pk == own_pk),
+            EventData::Rot(rot) => {
+                let own_npk = &self
+                    .get_state()?
+                    .ok_or(Error::SemanticError("Unknown state".into()))?
+                    .current
+                    .next_keys_data
+                    .next_key_hashes[0];
+                rot.key_config
+                    .public_keys
+                    .iter()
+                    .position(|pk| own_npk.verify_binding(pk.to_str().as_bytes()))
+            }
             EventData::Dip(dip) => dip
                 .inception_data
                 .key_config

--- a/keriox_core/src/error/mod.rs
+++ b/keriox_core/src/error/mod.rs
@@ -64,8 +64,8 @@ pub enum Error {
     #[error("Signature duplicate while verifing")]
     DuplicateSignature,
 
-    #[error("To many signatures while verifing")]
-    ToManySignatures,
+    #[error("Too many signatures while verifing")]
+    TooManySignatures,
 
     #[error("Not enough receipts")]
     NotEnoughReceiptsError,

--- a/keriox_core/src/error/mod.rs
+++ b/keriox_core/src/error/mod.rs
@@ -61,6 +61,12 @@ pub enum Error {
     #[error("Not enough signatures while verifying")]
     NotEnoughSigsError,
 
+    #[error("Signature duplicate while verifing")]
+    DuplicateSignature,
+
+    #[error("To many signatures while verifing")]
+    ToManySignatures,
+
     #[error("Not enough receipts")]
     NotEnoughReceiptsError,
 

--- a/keriox_core/src/event/sections/key_config.rs
+++ b/keriox_core/src/event/sections/key_config.rs
@@ -67,27 +67,29 @@ impl KeyConfig {
     /// Verifies the given sigs against the given message using the KeyConfigs
     /// Public Keys, according to the indexes in the sigs.
     pub fn verify(&self, message: &[u8], sigs: &[AttachedSignaturePrefix]) -> Result<bool, Error> {
+        // there are no duplicates
+        if !(sigs
+            .iter()
+            .fold(vec![0u64; self.public_keys.len()], |mut acc, sig| {
+                acc[sig.index as usize] += 1;
+                acc
+            })
+            .iter()
+            .all(|n| *n <= 1))
+        {
+            Err(Error::DuplicateSignature)
+        } else if
+        // check if there are not too many
+        sigs.len() > self.public_keys.len() {
+            Err(Error::ToManySignatures)
+
         // ensure there's enough sigs
-        if !self.threshold.enough_signatures(
+        } else if self.threshold.enough_signatures(
             &sigs
                 .iter()
                 .map(|sig| sig.index as usize)
                 .collect::<Vec<_>>(),
         )? {
-            Err(Error::NotEnoughSigsError)
-        } else if
-        // and that there are not too many
-        sigs.len() <= self.public_keys.len()
-            // and that there are no duplicates
-            && sigs
-                .iter()
-                .fold(vec![0u64; self.public_keys.len()], |mut acc, sig| {
-                    acc[sig.index as usize] += 1;
-                    acc
-                })
-                .iter()
-                .all(|n| *n <= 1)
-        {
             Ok(sigs
                 .iter()
                 .fold(Ok(true), |acc: Result<bool, Error>, sig| {
@@ -101,7 +103,7 @@ impl KeyConfig {
                             .and_then(|key: &BasicPrefix| key.verify(message, &sig.signature))?)
                 })?)
         } else {
-            Err(Error::SemanticError("Invalid signatures set".into()))
+            Err(Error::NotEnoughSigsError)
         }
     }
 
@@ -256,7 +258,7 @@ fn test_threshold() -> Result<(), Error> {
             signatures[0].clone(),
         ],
     );
-    assert!(matches!(st, Err(Error::NotEnoughSigsError)));
+    assert!(matches!(st, Err(Error::DuplicateSignature)));
 
     Ok(())
 }

--- a/keriox_core/src/event/sections/key_config.rs
+++ b/keriox_core/src/event/sections/key_config.rs
@@ -81,7 +81,7 @@ impl KeyConfig {
         } else if
         // check if there are not too many
         sigs.len() > self.public_keys.len() {
-            Err(Error::ToManySignatures)
+            Err(Error::TooManySignatures)
 
         // ensure there's enough sigs
         } else if self.threshold.enough_signatures(

--- a/keriox_core/src/keys/mod.rs
+++ b/keriox_core/src/keys/mod.rs
@@ -4,9 +4,9 @@ use k256::ecdsa::{signature::Signer as EcdsaSigner, Signature as EcdsaSignature,
 use k256::ecdsa::{signature::Verifier as EcdsaVerifier, VerifyingKey};
 use zeroize::Zeroize;
 
-#[derive(Debug, Clone, PartialEq, Hash, Eq)]
+#[derive(Debug, Clone, PartialEq, Hash, Eq, Default)]
 pub struct PublicKey {
-    public_key: Vec<u8>,
+    pub public_key: Vec<u8>,
 }
 
 impl PublicKey {

--- a/keriox_core/src/processor/escrow.rs
+++ b/keriox_core/src/processor/escrow.rs
@@ -249,13 +249,17 @@ impl PartiallySignedEscrow {
             .get(&id)
             .map(|events| events.filter(|event| event.event_message == signed_event.event_message))
         {
-            let new_sigs: Vec<_> = esc
-                .flat_map(|ev| ev.signatures)
-                .chain(signed_event.signatures.clone().into_iter())
-                .collect();
+            let mut signatures = esc.flat_map(|ev| ev.signatures).collect::<Vec<_>>();
+            let signatures_from_event = signed_event.signatures.clone();
+            let mut without_duplicates = signatures_from_event
+                .into_iter()
+                .filter(|sig| !signatures.contains(sig))
+                .collect::<Vec<_>>();
+
+            signatures.append(&mut without_duplicates);
 
             let new_event = SignedEventMessage {
-                signatures: new_sigs,
+                signatures: signatures,
                 ..signed_event.to_owned()
             };
 
@@ -282,10 +286,16 @@ impl PartiallySignedEscrow {
                 Err(Error::SignatureVerificationError) => {
                     // ignore
                 }
-                Err(_e) => {
+                Err(Error::NotEnoughSigsError) => {
                     //keep in escrow and save new partially signed event
-                    self.escrowed_partially_signed
-                        .add(&id, signed_event.clone())?;
+                    let to_add = SignedEventMessage {
+                        signatures: without_duplicates,
+                        ..signed_event.to_owned()
+                    };
+                    self.escrowed_partially_signed.add(&id, to_add)?;
+                }
+                Err(e) => {
+                    // keep in escrow
                 }
             }
         } else {

--- a/keriox_core/src/processor/escrow.rs
+++ b/keriox_core/src/processor/escrow.rs
@@ -251,12 +251,12 @@ impl PartiallySignedEscrow {
         {
             let mut signatures = esc.flat_map(|ev| ev.signatures).collect::<Vec<_>>();
             let signatures_from_event = signed_event.signatures.clone();
-            let mut without_duplicates = signatures_from_event
+            let without_duplicates = signatures_from_event
                 .into_iter()
                 .filter(|sig| !signatures.contains(sig))
                 .collect::<Vec<_>>();
 
-            signatures.append(&mut without_duplicates);
+                signatures.append(&mut without_duplicates.clone());
 
             let new_event = SignedEventMessage {
                 signatures: signatures,

--- a/keriox_core/src/processor/escrow_tests.rs
+++ b/keriox_core/src/processor/escrow_tests.rs
@@ -610,6 +610,13 @@ fn test_partially_sign_escrow() -> Result<(), Error> {
     let ixn2 = br#"{"v":"KERI10JSON0000cb_","t":"ixn","d":"ErcMMcfO4fdplItWB_42GwyY21u0pJkQEVDvMmrLVgFc","i":"EOsgPPbBijCbpu3R9N-TMdURgcoFqrjUf3rQiIaJ5L7M","s":"1","p":"EOsgPPbBijCbpu3R9N-TMdURgcoFqrjUf3rQiIaJ5L7M","a":[]}-AABAAye1jlp6iz6h5raVAavZEEahPQ7mUVHxegfjgZCjaWA-UcSQi5ic59-PKQ0tlEHlNHaeKIPts0lvONpW71dgOAg"#;
     let ixn_second_sig = parse_messagee(ixn2);
 
+    let ixn_event = if let Message::Notice(Notice::Event(ev)) = ixn_first_sig.clone() {
+        Some(ev.event_message)
+    } else {
+        None
+    }
+    .unwrap();
+
     processor.process(&ixn_first_sig)?;
 
     // check if event was accepted into kel
@@ -631,7 +638,7 @@ fn test_partially_sign_escrow() -> Result<(), Error> {
     // Now event is fully signed, check if escrow is empty
     assert_eq!(
         ps_escrow
-            .get_partially_signed_for_event(icp_event)
+            .get_partially_signed_for_event(ixn_event)
             .unwrap()
             .count(),
         0


### PR DESCRIPTION
Changes:
* use common `query_mailbox` function for querying group and own mailbox,
* update the way of computing public key index.