### PR TITLE
Use `sad_macros`

### DIFF
--- a/components/controller/src/identifier_controller.rs
+++ b/components/controller/src/identifier_controller.rs
@@ -112,7 +112,7 @@ impl IdentifierController {
     ) -> Result<(KeriEvent<KeyEvent>, ExchangeMessage), ControllerError> {
         let delegate = delegated_event.data.get_prefix();
         let delegated_seal = {
-            let event_digest = delegated_event.get_digest();
+            let event_digest = delegated_event.digest()?;
             let sn = delegated_event.data.get_sn();
             Seal::Event(EventSeal {
                 prefix: delegate.clone(),
@@ -278,7 +278,7 @@ impl IdentifierController {
             let sigs: Vec<_> = if let Some(receipts) = self.source.storage.get_nt_receipts(
                 &to_forward.data.get_prefix(),
                 to_forward.data.get_sn(),
-                &to_forward.get_digest(),
+                &to_forward.digest()?,
             )? {
                 receipts
                     .signatures

--- a/components/controller/src/lib.rs
+++ b/components/controller/src/lib.rs
@@ -310,9 +310,9 @@ impl Controller {
         let (prefix, sn, digest) = (
             message.event_message.data.get_prefix(),
             message.event_message.data.get_sn(),
-            message.event_message.get_digest(),
+            message.event_message.digest(),
         );
-        let rcts_from_db = self.storage.get_nt_receipts(&prefix, sn, &digest)?;
+        let rcts_from_db = self.storage.get_nt_receipts(&prefix, sn, &digest?)?;
 
         if let Some(receipt) = rcts_from_db {
             // send receipts to all witnesses

--- a/components/controller/src/mailbox_updating.rs
+++ b/components/controller/src/mailbox_updating.rs
@@ -133,7 +133,7 @@ impl IdentifierController {
             .get_event_by_sn_and_digest(
                 event.event_message.data.get_sn(),
                 &id,
-                &event.event_message.get_digest(),
+                &event.event_message.digest()?,
             );
 
         let own_index = self.get_index(&event.event_message.data)?;
@@ -227,7 +227,7 @@ impl IdentifierController {
                 let seal = Seal::Event(EventSeal {
                     prefix: id,
                     sn: event_to_confirm.event_message.data.get_sn(),
-                    event_digest: event_to_confirm.event_message.get_digest(),
+                    event_digest: event_to_confirm.event_message.digest()?,
                 });
 
                 let ixn = self.anchor_group(group_id, &[seal])?;

--- a/components/witness/src/tests.rs
+++ b/components/witness/src/tests.rs
@@ -491,8 +491,8 @@ pub fn test_key_state_notice() -> Result<(), Error> {
     );
     assert!(matches!(ksn_db, Some(_)));
 
-    let ksn_from_db_digest = ksn_db.unwrap().reply.get_digest();
-    let processed_ksn_digest = new_reply.reply.get_digest();
+    let ksn_from_db_digest = ksn_db.unwrap().reply.digest()?;
+    let processed_ksn_digest = new_reply.reply.digest()?;
     assert_eq!(ksn_from_db_digest, processed_ksn_digest);
 
     let new_bob_rot = bob.rotate(None, None, None)?;
@@ -507,8 +507,8 @@ pub fn test_key_state_notice() -> Result<(), Error> {
         &signed_rpy.signature.get_signer().unwrap(),
     );
     assert!(matches!(ksn_db, Some(_)));
-    let ksn_from_db_digest = ksn_db.unwrap().reply.get_digest();
-    let out_of_order_ksn_digest = trans_rpy.reply.get_digest();
+    let ksn_from_db_digest = ksn_db.unwrap().reply.digest()?;
+    let out_of_order_ksn_digest = trans_rpy.reply.digest()?;
     assert_ne!(ksn_from_db_digest, out_of_order_ksn_digest);
     assert_eq!(ksn_from_db_digest, processed_ksn_digest);
 
@@ -522,7 +522,7 @@ pub fn test_key_state_notice() -> Result<(), Error> {
         &signed_rpy.signature.get_signer().unwrap(),
     );
     assert!(matches!(ksn_db, Some(_)));
-    let ksn_from_db_digest = ksn_db.unwrap().reply.get_digest();
+    let ksn_from_db_digest = ksn_db.unwrap().reply.digest()?;
     assert_eq!(ksn_from_db_digest, out_of_order_ksn_digest);
 
     Ok(())
@@ -951,7 +951,7 @@ pub fn test_delegated_multisig() -> Result<(), ActorError> {
     )?;
 
     let group_id = group_dip.event_message.data.get_prefix();
-    let dip_digest = group_dip.event_message.get_digest();
+    let dip_digest = group_dip.event_message.digest()?;
     assert_eq!(exchange_messages.len(), 1);
 
     // Send exchange message from controller 1 to controller 2
@@ -1294,7 +1294,7 @@ pub fn test_delegating_multisig() -> Result<(), ActorError> {
         child.create_forward_message(&delegator_group_id, &dip, ForwardTopic::Delegate)?;
 
     let delegated_child_id = dip.event_message.data.get_prefix();
-    let dip_digest = dip.event_message.get_digest();
+    let dip_digest = dip.event_message.digest()?;
 
     // Send delegation request to witness.
     witness.process_exchange(delegation_request)?;

--- a/keriox_core/Cargo.toml
+++ b/keriox_core/Cargo.toml
@@ -26,9 +26,10 @@ mailbox = ["query"]
 [dependencies]
 bytes = "1.3.0"
 http = "0.2.8"
-said = { git = "https://github.com/THCLab/cesrox" } 
-cesrox = { git = "https://github.com/THCLab/cesrox", features = ["cesr-proof"] }
-version = { git = "https://github.com/THCLab/cesrox" }
+said = { git = "https://github.com/THCLab/cesrox", branch = "sad" } 
+sad_macros = { git = "https://github.com/THCLab/cesrox", branch = "sad" } 
+cesrox = { git = "https://github.com/THCLab/cesrox", features = ["cesr-proof"], branch = "sad" }
+version = { git = "https://github.com/THCLab/cesrox", branch = "sad" }
 ed25519-dalek = "1.0.1"
 k256 = { version = "0.9", features = ["ecdsa", "sha256", "zeroize"] }
 blake2 = "0.9.1"

--- a/keriox_core/Cargo.toml
+++ b/keriox_core/Cargo.toml
@@ -26,10 +26,10 @@ mailbox = ["query"]
 [dependencies]
 bytes = "1.3.0"
 http = "0.2.8"
-said = { git = "https://github.com/THCLab/cesrox", branch = "sad" } 
-sad_macros = { git = "https://github.com/THCLab/cesrox", branch = "sad" } 
-cesrox = { git = "https://github.com/THCLab/cesrox", features = ["cesr-proof"], branch = "sad" }
-version = { git = "https://github.com/THCLab/cesrox", branch = "sad" }
+said = { git = "https://github.com/THCLab/cesrox", tag = "v0.1.4"} 
+sad_macros = { git = "https://github.com/THCLab/cesrox", tag = "v0.1.4"} 
+cesrox = { git = "https://github.com/THCLab/cesrox", tag = "v0.1.4", features = ["cesr-proof"]}
+version = { git = "https://github.com/THCLab/cesrox", tag = "v0.1.4"}
 ed25519-dalek = "1.0.1"
 k256 = { version = "0.9", features = ["ecdsa", "sha256", "zeroize"] }
 blake2 = "0.9.1"

--- a/keriox_core/src/actor/simple_controller.rs
+++ b/keriox_core/src/actor/simple_controller.rs
@@ -787,7 +787,7 @@ impl<K: KeyManager> SimpleController<K> {
         let fully_signed_event = self.not_fully_witnessed_escrow.get_event_by_sn_and_digest(
             event.event_message.data.get_sn(),
             &id,
-            &event.event_message.get_digest(),
+            &event.event_message.digest()?,
         );
 
         let own_index = self.get_index(&event.event_message.data)?;
@@ -820,7 +820,7 @@ impl<K: KeyManager> SimpleController<K> {
         let seal = Seal::Event(EventSeal {
             prefix: id.clone(),
             sn: event_to_confirm.event_message.data.get_sn(),
-            event_digest: event_to_confirm.event_message.get_digest(),
+            event_digest: event_to_confirm.event_message.digest()?,
         });
 
         let ixn = self.anchor(&vec![seal])?;
@@ -839,7 +839,7 @@ impl<K: KeyManager> SimpleController<K> {
         let seal = Seal::Event(EventSeal {
             prefix: id.clone(),
             sn: event_to_confirm.event_message.data.get_sn(),
-            event_digest: event_to_confirm.event_message.get_digest(),
+            event_digest: event_to_confirm.event_message.digest()?,
         });
 
         let ixn = self.anchor_group(group_id, &vec![seal])?;

--- a/keriox_core/src/error/mod.rs
+++ b/keriox_core/src/error/mod.rs
@@ -111,6 +111,9 @@ pub enum Error {
     #[error("Incorrect event digest")]
     IncorrectDigest,
 
+    #[error("No digest of event set")]
+    EventDigestError,
+
     #[cfg(feature = "query")]
     #[error(transparent)]
     QueryError(#[from] crate::query::QueryError),

--- a/keriox_core/src/event/event_data/delegated/mod.rs
+++ b/keriox_core/src/event/event_data/delegated/mod.rs
@@ -36,7 +36,7 @@ impl DelegatedInceptionEvent {
             &(&derivation).into(),
             format,
         )?;
-        let digest = derivation.derive(&dummy_event.encode()?);
+        let digest = dummy_event.prefix.unwrap();
         let event = KeyEvent::new(
             IdentifierPrefix::SelfAddressing(digest.clone()),
             0,
@@ -44,7 +44,7 @@ impl DelegatedInceptionEvent {
         );
         Ok(KeriEvent {
             serialization_info: dummy_event.serialization_info,
-            digest,
+            digest: Some(digest),
             data: event,
         })
     }

--- a/keriox_core/src/event/event_data/inception.rs
+++ b/keriox_core/src/event/event_data/inception.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::{
     error::Error,
     event::{sections::seal::Seal, KeyEvent},
-    event_message::{dummy_event::DummyInceptionEvent, msg::KeriEvent, EventTypeTag, Typeable},
+    event_message::{dummy_event::DummyInceptionEvent, msg::KeriEvent, Typeable},
     prefix::IdentifierPrefix,
     state::{EventSemantics, IdentifierState, LastEstablishmentData},
 };

--- a/keriox_core/src/event/event_data/inception.rs
+++ b/keriox_core/src/event/event_data/inception.rs
@@ -57,7 +57,8 @@ impl InceptionEvent {
     ) -> Result<KeriEvent<KeyEvent>, Error> {
         let dummy_event =
             DummyInceptionEvent::dummy_inception_data(self.clone(), &(&derivation).into(), format)?;
-        let digest = derivation.derive(&dummy_event.encode()?);
+        println!("in incept_self_addressing: {}", String::from_utf8(dummy_event.encode()?).unwrap());
+        let digest = dummy_event.prefix.unwrap();
         let event = KeyEvent::new(
             IdentifierPrefix::SelfAddressing(digest.clone()),
             0,
@@ -65,7 +66,7 @@ impl InceptionEvent {
         );
         Ok(KeriEvent {
             serialization_info: dummy_event.serialization_info,
-            digest,
+            digest: Some(digest),
             data: event,
         })
     }

--- a/keriox_core/src/event/event_data/mod.rs
+++ b/keriox_core/src/event/event_data/mod.rs
@@ -19,7 +19,7 @@ pub use self::{
 /// Event Data
 ///
 /// Event Data conveys the semantic content of a KERI event.
-#[derive(Serialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged, rename_all = "lowercase")]
 pub enum EventData {
     Icp(InceptionEvent),
@@ -27,40 +27,6 @@ pub enum EventData {
     Ixn(InteractionEvent),
     Dip(DelegatedInceptionEvent),
     Drt(RotationEvent),
-}
-
-impl<'de> Deserialize<'de> for EventData {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        // Helper struct for adding tag to properly deserialize 't' field
-        #[derive(Deserialize)]
-        struct EventType {
-            t: EventTypeTag,
-        }
-
-        let v = Value::deserialize(deserializer)?;
-        let m = EventType::deserialize(&v).map_err(de::Error::custom)?;
-        match m.t {
-            EventTypeTag::Icp => Ok(EventData::Icp(
-                InceptionEvent::deserialize(&v).map_err(de::Error::custom)?,
-            )),
-            EventTypeTag::Rot => Ok(EventData::Rot(
-                RotationEvent::deserialize(&v).map_err(de::Error::custom)?,
-            )),
-            EventTypeTag::Ixn => Ok(EventData::Ixn(
-                InteractionEvent::deserialize(&v).map_err(de::Error::custom)?,
-            )),
-            EventTypeTag::Dip => Ok(EventData::Dip(
-                DelegatedInceptionEvent::deserialize(&v).map_err(de::Error::custom)?,
-            )),
-            EventTypeTag::Drt => Ok(EventData::Drt(
-                RotationEvent::deserialize(&v).map_err(de::Error::custom)?,
-            )),
-            _ => Err(Error::SemanticError("Not a key event".into())).map_err(de::Error::custom)?,
-        }
-    }
 }
 
 impl EventSemantics for EventData {

--- a/keriox_core/src/event/event_data/mod.rs
+++ b/keriox_core/src/event/event_data/mod.rs
@@ -8,8 +8,7 @@ use crate::{
     event_message::{EventTypeTag, Typeable},
     state::{EventSemantics, IdentifierState},
 };
-use serde::{de, Deserialize, Deserializer, Serialize};
-use serde_json::Value;
+use serde::{Deserialize, Serialize};
 
 pub use self::{
     delegated::DelegatedInceptionEvent, inception::InceptionEvent, interaction::InteractionEvent,
@@ -22,10 +21,10 @@ pub use self::{
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged, rename_all = "lowercase")]
 pub enum EventData {
+    Dip(DelegatedInceptionEvent),
     Icp(InceptionEvent),
     Rot(RotationEvent),
     Ixn(InteractionEvent),
-    Dip(DelegatedInceptionEvent),
     Drt(RotationEvent),
 }
 

--- a/keriox_core/src/event/receipt.rs
+++ b/keriox_core/src/event/receipt.rs
@@ -15,7 +15,7 @@ use version::serialization_info::SerializationInfo;
 pub struct Receipt {
     #[serde(rename = "v")]
     pub serialization_info: SerializationInfo,
-    
+
     #[serde(rename = "t")]
     pub event_type: EventTypeTag,
 

--- a/keriox_core/src/event/receipt.rs
+++ b/keriox_core/src/event/receipt.rs
@@ -9,10 +9,16 @@ use serde_hex::{Compact, SerHex};
 use version::serialization_info::SerializationFormats;
 use version::serialization_info::SerializationInfo;
 
+/// Receipt event is not a SAD. That's because TypedEvent wrapper is not used here.
+/// It's digest field is digest of receipted event, not digest of receipt itself.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Receipt {
     #[serde(rename = "v")]
     pub serialization_info: SerializationInfo,
+    
+    #[serde(rename = "t")]
+    pub event_type: EventTypeTag,
+
     /// Receipted Event Digest
     ///
     /// A Qualified Digest of the event which this receipt is made for
@@ -41,6 +47,7 @@ impl Receipt {
             receipted_event_digest,
             prefix,
             sn,
+            event_type: EventTypeTag::Rct,
         };
         let len = receipt.encode().unwrap().len();
         receipt.serialization_info.size = len;

--- a/keriox_core/src/event_message/cesr_adapter.rs
+++ b/keriox_core/src/event_message/cesr_adapter.rs
@@ -32,7 +32,7 @@ use crate::{
 };
 
 use super::{
-    msg::KeriEvent,
+    msg::{KeriEvent, TypedEvent},
     signature::Nontransferable,
     signed_event_message::{
         Message, Notice, Op, SignedEventMessage, SignedNontransferableReceipt,
@@ -116,8 +116,10 @@ impl From<&SignedEventMessage> for ParsedData {
     }
 }
 
-impl<T: Serialize, D: Typeable<TypeTag = T> + Serialize + Clone> From<KeriEvent<D>> for Payload {
-    fn from(pd: KeriEvent<D>) -> Self {
+impl<T: Serialize + Clone, D: Typeable<TypeTag = T> + Serialize + Clone> From<TypedEvent<T, D>>
+    for Payload
+{
+    fn from(pd: TypedEvent<T, D>) -> Self {
         match pd.serialization_info.kind {
             SerializationFormats::JSON => Payload::JSON(pd.encode().unwrap()),
             SerializationFormats::MGPK => Payload::MGPK(pd.encode().unwrap()),

--- a/keriox_core/src/event_message/cesr_adapter.rs
+++ b/keriox_core/src/event_message/cesr_adapter.rs
@@ -560,11 +560,14 @@ pub fn signed_exchange(exn: ExchangeMessage, attachments: Vec<Group>) -> Result<
 
 #[cfg(test)]
 pub mod test {
-    use std::convert::{TryInto};
+    use std::convert::TryInto;
 
     use cesrox::{parse, parse_many};
 
-    use crate::{event_message::{cesr_adapter::EventType, msg::KeriEvent}, event::{KeyEvent, receipt::Receipt}};
+    use crate::{
+        event::{receipt::Receipt, KeyEvent},
+        event_message::{cesr_adapter::EventType, msg::KeriEvent},
+    };
 
     #[test]
     fn test_signed_event() {
@@ -616,7 +619,7 @@ pub mod test {
         assert_eq!(event.to_cesr().unwrap(), stream);
 
         let event: Receipt = serde_json::from_slice(stream).unwrap();
-        assert_eq!(String::from_utf8(event.encode().unwrap()).unwrap(), String::from_utf8(stream.to_vec()).unwrap());
+        assert_eq!(event.encode().unwrap(), stream.to_vec());
     }
 
     #[cfg(feature = "query")]

--- a/keriox_core/src/event_message/cesr_adapter.rs
+++ b/keriox_core/src/event_message/cesr_adapter.rs
@@ -560,13 +560,11 @@ pub fn signed_exchange(exn: ExchangeMessage, attachments: Vec<Group>) -> Result<
 
 #[cfg(test)]
 pub mod test {
-    use std::convert::TryInto;
-
     use cesrox::{parse, parse_many};
 
     use crate::{
         event::{receipt::Receipt, KeyEvent},
-        event_message::{cesr_adapter::EventType, msg::KeriEvent},
+        event_message::msg::KeriEvent,
     };
 
     #[test]
@@ -625,6 +623,9 @@ pub mod test {
     #[cfg(feature = "query")]
     #[test]
     fn test_qry() {
+        use std::convert::TryInto;
+
+        use crate::event_message::cesr_adapter::EventType;
         // taken from keripy keripy/tests/core/test_eventing.py::test_messegize
         let qry_event = br#"{"v":"KERI10JSON0000c9_","t":"qry","d":"EGN68_seecuzXQO15FFGJLVwZCBCPYW-hy29fjWWPQbp","dt":"2021-01-01T00:00:00.000000+00:00","r":"log","rr":"","q":{"i":"DAvCLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI"}}"#;
         let rest = "something more".as_bytes();
@@ -638,8 +639,11 @@ pub mod test {
         assert_eq!(&event.to_cesr().unwrap(), qry_event);
     }
 
+    #[cfg(feature = "mailbox")]
     #[test]
     fn test_exn() {
+        use crate::event_message::cesr_adapter::EventType;
+        use std::convert::TryInto;
         let exn_event = br#"{"v":"KERI10JSON0002f1_","t":"exn","d":"EBLqTGJXK8ViUGXMOO8_LXbetpjJX8CY_SbA134RIZmf","dt":"2022-10-25T09:53:04.119676+00:00","r":"/fwd","q":{"pre":"EKYLUMmNPZeEs77Zvclf0bSN5IN-mLfLpx2ySb-HDlk4","topic":"multisig"},"a":{"v":"KERI10JSON000215_","t":"icp","d":"EC61gZ9lCKmHAS7U5ehUfEbGId5rcY0D7MirFZHDQcE2","i":"EC61gZ9lCKmHAS7U5ehUfEbGId5rcY0D7MirFZHDQcE2","s":"0","kt":"2","k":["DOZlWGPfDHLMf62zSFzE8thHmnQUOgA3_Y-KpOyF9ScG","DHGb2qY9WwZ1sBnC9Ip0F-M8QjTM27ftI-3jTGF9mc6K"],"nt":"2","n":["EBvD5VIVvf6NpP9GRmTqu_Cd1KN0RKrKNfPJ-uhIxurj","EHlpcaxffvtcpoUUMTc6tpqAVtb2qnOYVk_3HRsZ34PH"],"bt":"3","b":["BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha","BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM","BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX"],"c":[],"a":[]}}-HABEJccSRTfXYF6wrUVuenAIHzwcx3hJugeiJsEKmndi5q1-AABAAArUSuSpts5zDQ7CgPcy305IxhAG8lOjf-r_d5yYQXp18OD9No_gd2McOOjGWMfjyLVjDK529pQcbvNv9Uwc6gH-LAZ5AABAA-a-AABAABYHc_lpuYF3SPNWvyPjzek7yquw69Csc6pLv5vrXHkFAFDcwNNTVxq7ZpxpqOO0CAIS-9Qj1zMor-cwvMHAmkE')"#;
 
         let (_extra, event) = parse(exn_event).unwrap();
@@ -652,6 +656,8 @@ pub mod test {
     #[cfg(feature = "query")]
     #[test]
     fn test_reply() {
+        use crate::event_message::cesr_adapter::EventType;
+        use std::convert::TryInto;
         let rpy = br#"{"v":"KERI10JSON00029d_","t":"rpy","d":"EYFMuK9IQmHvq9KaJ1r67_MMCq5GnQEgLyN9YPamR3r0","dt":"2021-01-01T00:00:00.000000+00:00","r":"/ksn/E7YbTIkWWyNwOxZQTTnrs6qn8jFbu2A8zftQ33JYQFQ0","a":{"v":"KERI10JSON0001e2_","i":"E7YbTIkWWyNwOxZQTTnrs6qn8jFbu2A8zftQ33JYQFQ0","s":"3","p":"EF7f4gNFCbJz6ZHLacIi_bbIq7kaWAFOzX7ncU_vs5Qg","d":"EOPSPvHHVmU9IIdHa5ksisoVrOnmHRps_tx3OsZSQQ30","f":"3","dt":"2021-01-01T00:00:00.000000+00:00","et":"rot","kt":"1","k":["DrcAz_gmDTuWIHn_mOQDeSK_aJIRiw5IMzPD7igzEDb0"],"nt":"1","n":["EK7ZUmFebD2st48Yvtzc9LajV3Yg2mkeeDzVRL-7uKrU"],"bt":"0","b":[],"c":[],"ee":{"s":"3","d":"EOPSPvHHVmU9IIdHa5ksisoVrOnmHRps_tx3OsZSQQ30","br":[],"ba":[]},"di":""}}-VA0-FABE7YbTIkWWyNwOxZQTTnrs6qn8jFbu2A8zftQ33JYQFQ00AAAAAAAAAAAAAAAAAAAAAAwEOPSPvHHVmU9IIdHa5ksisoVrOnmHRps_tx3OsZSQQ30-AABAAYsqumzPM0bIo04gJ4Ln0zAOsGVnjHZrFjjjS49hGx_nQKbXuD1D4J_jNoEa4TPtPDnQ8d0YcJ4TIRJb-XouJBg"#;
         let rest = "something more".as_bytes();
         let stream = [rpy, rest].concat();

--- a/keriox_core/src/event_message/cesr_adapter.rs
+++ b/keriox_core/src/event_message/cesr_adapter.rs
@@ -560,11 +560,11 @@ pub fn signed_exchange(exn: ExchangeMessage, attachments: Vec<Group>) -> Result<
 
 #[cfg(test)]
 pub mod test {
-    use std::convert::TryInto;
+    use std::convert::{TryInto};
 
     use cesrox::{parse, parse_many};
 
-    use crate::event_message::cesr_adapter::EventType;
+    use crate::{event_message::{cesr_adapter::EventType, msg::KeriEvent}, event::{KeyEvent, receipt::Receipt}};
 
     #[test]
     fn test_signed_event() {
@@ -579,47 +579,44 @@ pub mod test {
     fn test_key_event_parsing() {
         // Inception event.
         let stream = br#"{"v":"KERI10JSON0000fd_","t":"icp","d":"EMW0zK3bagYPO6gx3w7Ua90f-I7x5kGIaI4Xeq9W8_As","i":"BFs8BBx86uytIM0D2BhsE5rrqVIT8ef8mflpNceHo4XH","s":"0","kt":"1","k":["BFs8BBx86uytIM0D2BhsE5rrqVIT8ef8mflpNceHo4XH"],"nt":"0","n":[],"bt":"0","b":[],"c":[],"a":[]}"#;
-        let event = parse(stream);
-        assert!(event.is_ok());
-        assert_eq!(event.unwrap().1.to_cesr().unwrap(), stream);
+        let event: KeriEvent<KeyEvent> = serde_json::from_slice(stream).unwrap();
+        assert_eq!(event.encode().unwrap(), stream);
 
         // Rotation event.
         let stream = br#"{"v":"KERI10JSON000160_","t":"rot","d":"EFl8nvRCbN2xQJI75nBXp-gaXuHJw8zheVjwMN_rB-pb","i":"DFs8BBx86uytIM0D2BhsE5rrqVIT8ef8mflpNceHo4XH","s":"1","p":"EJQUyxnzIAtmZPoq9f4fExeGN0qfJmaFnUEKTwIiTBPj","kt":"1","k":["DB4GWvru73jWZKpNgMQp8ayDRin0NG0Ymn_RXQP_v-PQ"],"nt":"1","n":["EIsKL3B6Zz5ICGxCQp-SoLXjwOrdlSbLJrEn21c2zVaU"],"bt":"0","br":[],"ba":[],"a":[]}"#;
-        let event = parse(stream);
-        assert!(event.is_ok());
-        assert_eq!(event.unwrap().1.to_cesr().unwrap(), stream);
+        let event: KeriEvent<KeyEvent> = serde_json::from_slice(stream).unwrap();
+        assert_eq!(event.encode().unwrap(), stream);
 
         // Interaction event without seals.
         let stream = br#"{"v":"KERI10JSON0000cb_","t":"ixn","d":"EKKccCumVQdgxvsrSXvuTtjmS28Xqf3zRJ8T6peKgl9J","i":"DFs8BBx86uytIM0D2BhsE5rrqVIT8ef8mflpNceHo4XH","s":"2","p":"ECauhEzA4DJDXVDnNQiGQ0sKXa6sx_GgS8Ebdzm4E-kQ","a":[]}"#;
-        let event = parse(stream);
-        assert!(event.is_ok());
-        assert_eq!(event.unwrap().1.to_cesr().unwrap(), stream);
+        let event: KeriEvent<KeyEvent> = serde_json::from_slice(stream).unwrap();
+        assert_eq!(event.encode().unwrap(), stream);
 
         // Interaction event with seal.
         let stream = br#"{"v":"KERI10JSON00013a_","t":"ixn","d":"EJtQndkvwnMpVGE5oVVbLWSCm-jLviGw1AOOkzBvNwsS","i":"EA_SbBUZYwqLVlAAn14d6QUBQCSReJlZ755JqTgmRhXH","s":"1","p":"EA_SbBUZYwqLVlAAn14d6QUBQCSReJlZ755JqTgmRhXH","a":[{"i":"EHng2fV42DdKb5TLMIs6bbjFkPNmIdQ5mSFn6BTnySJj","s":"0","d":"EHng2fV42DdKb5TLMIs6bbjFkPNmIdQ5mSFn6BTnySJj"}]}"#;
-        let event = parse(stream);
-        assert!(event.is_ok());
-        assert_eq!(event.unwrap().1.to_cesr().unwrap(), stream);
+        let event: KeriEvent<KeyEvent> = serde_json::from_slice(stream).unwrap();
+        assert_eq!(event.encode().unwrap(), stream);
 
         // Delegated inception event.
-        let stream = br#"{"v":"KERI10JSON00015f_","t":"dip","d":"EN3PglLbr4mJblS4dyqbqlpUa735hVmLOhYUbUztxaiH","i":"EN3PglLbr4mJblS4dyqbqlpUa735hVmLOhYUbUztxaiH","s":"0","kt":"1","k":["DB4GWvru73jWZKpNgMQp8ayDRin0NG0Ymn_RXQP_v-PQ"],"nt":"1","n":["EIf-ENw7PrM52w4H-S7NGU2qVIfraXVIlV9hEAaMHg7W"],"bt":"0","b":[],"c":[],"a":[],"di":"EAdHxtdjCQUM-TVO8CgJAKb8ykXsFe4u9epTUQFCL7Yd"}"#;
-        let event = parse(stream);
-        assert_eq!(event.unwrap().1.to_cesr().unwrap(), stream);
+        let stream = br#"{"v":"KERI10JSON00015f_","t":"dip","d":"EHng2fV42DdKb5TLMIs6bbjFkPNmIdQ5mSFn6BTnySJj","i":"EHng2fV42DdKb5TLMIs6bbjFkPNmIdQ5mSFn6BTnySJj","s":"0","kt":"1","k":["DLitcfMnabnLt-PNCaXdVwX45wsG93Wd8eW9QiZrlKYQ"],"nt":"1","n":["EDjXvWdaNJx7pAIr72Va6JhHxc7Pf4ScYJG496ky8lK8"],"bt":"0","b":[],"c":[],"a":[],"di":"EA_SbBUZYwqLVlAAn14d6QUBQCSReJlZ755JqTgmRhXH"}"#;
+        let event: KeriEvent<KeyEvent> = serde_json::from_slice(stream).unwrap();
+        assert_eq!(event.encode().unwrap(), stream);
 
         // Delegated rotation event.
         let stream = br#"{"v":"KERI10JSON000160_","t":"drt","d":"EMBBBkaLV7i6wNgfz3giib2ItrHsr548mtIflW0Hrbuv","i":"EN3PglLbr4mJblS4dyqbqlpUa735hVmLOhYUbUztxaiH","s":"4","p":"EANkcl_QewzrRSKH2p9zUskHI462CuIMS_HQIO132Z30","kt":"1","k":["DPLt4YqQsWZ5DPztI32mSyTJPRESONvE9KbETtCVYIeH"],"nt":"1","n":["EIsKL3B6Zz5ICGxCQp-SoLXjwOrdlSbLJrEn21c2zVaU"],"bt":"0","br":[],"ba":[],"a":[]}"#;
-        let event = parse(stream);
-        assert!(event.is_ok());
-        assert_eq!(event.unwrap().1.to_cesr().unwrap(), stream);
+        let event: KeriEvent<KeyEvent> = serde_json::from_slice(stream).unwrap();
+        assert_eq!(event.encode().unwrap(), stream);
     }
 
     #[test]
     fn test_receipt_parsing() {
         // Receipt event
         let stream = br#"{"v":"KERI10JSON000091_","t":"rct","d":"EKKccCumVQdgxvsrSXvuTtjmS28Xqf3zRJ8T6peKgl9J","i":"DFs8BBx86uytIM0D2BhsE5rrqVIT8ef8mflpNceHo4XH","s":"0"}"#;
-        let event = parse(stream);
-        assert!(event.is_ok());
-        assert_eq!(event.unwrap().1.to_cesr().unwrap(), stream);
+        let event = parse(stream).unwrap().1;
+        assert_eq!(event.to_cesr().unwrap(), stream);
+
+        let event: Receipt = serde_json::from_slice(stream).unwrap();
+        assert_eq!(String::from_utf8(event.encode().unwrap()).unwrap(), String::from_utf8(stream.to_vec()).unwrap());
     }
 
     #[cfg(feature = "query")]

--- a/keriox_core/src/event_message/cesr_adapter.rs
+++ b/keriox_core/src/event_message/cesr_adapter.rs
@@ -79,7 +79,7 @@ impl EventType {
 impl From<&SignedEventMessage> for ParsedData {
     fn from(ev: &SignedEventMessage) -> Self {
         let mut attachments = if let Some(SourceSeal { sn, digest }) = ev.delegator_seal.clone() {
-            vec![Group::SourceSealCouples(vec![(sn, (&digest).into())])]
+            vec![Group::SourceSealCouples(vec![(sn, digest.into())])]
         } else {
             vec![]
         };
@@ -145,7 +145,7 @@ impl From<SignedTransferableReceipt> for ParsedData {
         let quadruple = (
             seal.prefix.into(),
             seal.sn,
-            (&seal.event_digest).into(),
+            seal.event_digest.into(),
             signatures,
         );
         let group = Group::TransIndexedSigGroups(vec![quadruple]);

--- a/keriox_core/src/event_message/dummy_event.rs
+++ b/keriox_core/src/event_message/dummy_event.rs
@@ -1,8 +1,6 @@
 use crate::{
     error::Error,
-    event::{
-        event_data::{DelegatedInceptionEvent, EventData, InceptionEvent},
-    },
+    event::event_data::{DelegatedInceptionEvent, EventData, InceptionEvent},
 };
 
 use super::{EventTypeTag, Typeable};
@@ -65,7 +63,7 @@ impl DummyInceptionEvent {
             sn: 0,
             data,
         };
-        let len = tmp_icp.derivative(derivation, &format).len();
+        let len = tmp_icp.derivation_data(derivation, &format).len();
         let serialization_info = SerializationInfo::new("KERI".to_string(), format, len);
         tmp_icp.serialization_info = serialization_info;
         Ok(tmp_icp)

--- a/keriox_core/src/event_message/dummy_event.rs
+++ b/keriox_core/src/event_message/dummy_event.rs
@@ -70,8 +70,7 @@ impl DummyInceptionEvent {
         let len = tmp_icp.derivative(derivation, &format).len();
         let serialization_info = SerializationInfo::new("KERI".to_string(), format, len);
         tmp_icp.serialization_info = serialization_info;
-        let icp = tmp_icp.compute_digest(derivation.clone(), format);
-        Ok(icp)
+        Ok(tmp_icp)
     }
 
     pub fn encode(&self) -> Result<Vec<u8>, Error> {

--- a/keriox_core/src/event_message/dummy_event.rs
+++ b/keriox_core/src/event_message/dummy_event.rs
@@ -2,13 +2,11 @@ use crate::{
     error::Error,
     event::{
         event_data::{DelegatedInceptionEvent, EventData, InceptionEvent},
-        KeyEvent,
     },
-    event_message::msg::KeriEvent,
 };
 
 use super::{EventTypeTag, Typeable};
-use cesrox::primitives::codes::self_addressing::{dummy_prefix, SelfAddressing};
+use cesrox::primitives::codes::self_addressing::SelfAddressing;
 use sad_macros::SAD;
 use said::{derivation::HashFunctionCode, sad::SAD, SelfAddressingIdentifier};
 use serde::Serialize;
@@ -71,9 +69,5 @@ impl DummyInceptionEvent {
         let serialization_info = SerializationInfo::new("KERI".to_string(), format, len);
         tmp_icp.serialization_info = serialization_info;
         Ok(tmp_icp)
-    }
-
-    pub fn encode(&self) -> Result<Vec<u8>, Error> {
-        Ok(self.serialization_info.serialize(&self).unwrap())
     }
 }

--- a/keriox_core/src/event_message/event_msg_builder.rs
+++ b/keriox_core/src/event_message/event_msg_builder.rs
@@ -294,7 +294,7 @@ impl ReceiptBuilder {
     pub fn build(&self) -> Result<Receipt, Error> {
         let prefix = self.receipted_event.data.get_prefix();
         let sn = self.receipted_event.data.get_sn();
-        let receipted_event_digest = self.receipted_event.get_digest();
+        let receipted_event_digest = self.receipted_event.digest()?;
         Ok(Receipt::new(
             self.format,
             receipted_event_digest,

--- a/keriox_core/src/event_message/key_event_message.rs
+++ b/keriox_core/src/event_message/key_event_message.rs
@@ -1,6 +1,4 @@
-use cesrox::primitives::codes::self_addressing::dummy_prefix;
 use said::{sad::SAD, SelfAddressingIdentifier};
-use version::serialization_info::SerializationInfo;
 
 use crate::{
     error::Error,
@@ -11,7 +9,7 @@ use crate::{
 
 use super::{
     dummy_event::DummyInceptionEvent, msg::KeriEvent, signature::Nontransferable,
-    signed_event_message::SignedEventMessage, EventTypeTag, Typeable,
+    signed_event_message::SignedEventMessage,
 };
 
 impl KeyEvent {

--- a/keriox_core/src/event_message/key_event_message.rs
+++ b/keriox_core/src/event_message/key_event_message.rs
@@ -45,20 +45,30 @@ impl KeriEvent<KeyEvent> {
         }
     }
 
-    fn to_derivation_data(&self) -> Result<Vec<u8>, Error> {
+    pub fn to_derivation_data(&self) -> Result<Vec<u8>, Error> {
         Ok(match self.data.get_event_data() {
             EventData::Icp(icp) => DummyInceptionEvent::dummy_inception_data(
                 icp,
                 &(&self.get_digest().derivation).into(),
                 self.serialization_info.kind,
             )?
-            .encode()?,
+            .derivative(
+                &(&self.get_digest().derivation).into(),
+                &self.serialization_info.kind,
+            )
+            .as_bytes()
+            .to_vec(),
             EventData::Dip(dip) => DummyInceptionEvent::dummy_delegated_inception_data(
                 dip,
                 &(&self.get_digest().derivation).into(),
                 self.serialization_info.kind,
             )?
-            .encode()?,
+            .derivative(
+                &(&self.get_digest().derivation).into(),
+                &self.serialization_info.kind,
+            )
+            .as_bytes()
+            .to_vec(),
             _ => self
                 .derivative(
                     &(&self.get_digest().derivation).into(),

--- a/keriox_core/src/event_message/key_event_message.rs
+++ b/keriox_core/src/event_message/key_event_message.rs
@@ -1,8 +1,4 @@
-use said::{
-    derivation::{HashFunction, HashFunctionCode},
-    sad::SAD,
-    SelfAddressingIdentifier,
-};
+use said::{derivation::HashFunctionCode, sad::SAD, SelfAddressingIdentifier};
 
 use crate::{
     error::Error,

--- a/keriox_core/src/event_message/mod.rs
+++ b/keriox_core/src/event_message/mod.rs
@@ -114,10 +114,10 @@ mod tests {
         signer::setup_signers,
         state::{EventSemantics, IdentifierState},
     };
-    use cesrox::primitives::{CesrPrimitive};
-    use said::derivation::HashFunctionCode;
+    use cesrox::primitives::CesrPrimitive;
     use ed25519_dalek::Keypair;
     use rand::rngs::OsRng;
+    use said::derivation::HashFunctionCode;
     use version::serialization_info::SerializationFormats;
 
     #[test]

--- a/keriox_core/src/event_message/mod.rs
+++ b/keriox_core/src/event_message/mod.rs
@@ -368,7 +368,7 @@ mod tests {
             .unwrap();
 
         let id_prefix = icp.data.get_prefix();
-        let icp_digest = icp.get_digest();
+        let icp_digest = icp.digest()?;
         assert_eq!(
             id_prefix,
             IdentifierPrefix::SelfAddressing(icp_digest.clone())
@@ -413,7 +413,7 @@ mod tests {
             ]))
             .build()?;
 
-        let rot_digest = rotation.get_digest();
+        let rot_digest = rotation.digest()?;
         let state = rotation.apply_to(state)?;
 
         assert_eq!(state.sn, 1);

--- a/keriox_core/src/event_message/msg.rs
+++ b/keriox_core/src/event_message/msg.rs
@@ -52,9 +52,7 @@ impl<T: Serialize + Clone, D: Serialize + Typeable<TypeTag = T> + Clone> TypedEv
             .unwrap())
         // .ok_or(Error::IncorrectDigest)
     }
-}
 
-impl<T: Serialize + Clone, D: Serialize + Typeable<TypeTag = T> + Clone> TypedEvent<T, D> {
     pub fn new(
         format: SerializationFormats,
         derivation: HashFunction,

--- a/keriox_core/src/event_message/msg.rs
+++ b/keriox_core/src/event_message/msg.rs
@@ -1,4 +1,5 @@
-use said::{derivation::HashFunction, SelfAddressingIdentifier};
+use sad_macros::SAD;
+use said::{derivation::HashFunction, derivation::HashFunctionCode, SelfAddressingIdentifier, sad::SAD};
 use serde::{Deserialize, Serialize, Serializer};
 use version::serialization_info::{SerializationFormats, SerializationInfo};
 
@@ -6,8 +7,8 @@ use crate::error::Error;
 
 use super::{dummy_event::DummyEvent, Typeable};
 
-#[derive(Deserialize, Debug, Clone, PartialEq)]
-pub struct KeriEvent<D> {
+#[derive(Deserialize, Debug, Clone, PartialEq, SAD)]
+pub struct KeriEvent<D: Serialize + Clone> {
     /// Serialization Information
     ///
     /// Encodes the version, size and serialization format of the event
@@ -18,22 +19,23 @@ pub struct KeriEvent<D> {
     /// While computing the digest, this field is replaced with sequence of `#`,
     /// its length depends on derivation type. Then it is replaced by computed
     /// SAI.
+    #[said]
     #[serde(rename = "d")]
-    pub digest: SelfAddressingIdentifier,
+    pub digest: Option<SelfAddressingIdentifier>,
     #[serde(flatten)]
     pub data: D,
 }
 
 impl<T: Serialize, D: Serialize + Typeable<TypeTag = T> + Clone> KeriEvent<D> {
     pub fn get_digest(&self) -> SelfAddressingIdentifier {
-        self.digest.clone()
+        self.digest.clone().unwrap()
     }
 
     pub fn dummy_event(&self) -> std::result::Result<Vec<u8>, Error> {
         DummyEvent::dummy_event(
             self.data.clone(),
             self.serialization_info.kind,
-            &(&self.digest.derivation).into(),
+            &(&self.digest.as_ref().unwrap().derivation).into(),
         )?
         .encode()
     }
@@ -53,14 +55,25 @@ impl<T: Serialize, D: Serialize + Typeable<TypeTag = T> + Clone> KeriEvent<D> {
         derivation: HashFunction,
         event: D,
     ) -> Result<Self, Error> {
-        let dummy_event = DummyEvent::dummy_event(event.clone(), format, &(&derivation).into())?;
+        let tmp_serialization_info = SerializationInfo::new_empty("KERI".to_string(), format);
+        
+        let mut tmp_self = Self { serialization_info: tmp_serialization_info, digest: None, data: event };
+        let encoded = tmp_self.derivative(&(&derivation).into(), &format);
+        println!("In KeriEvent new: {}", encoded);
 
-        let sai = derivation.derive(&dummy_event.encode()?);
-        Ok(Self {
-            serialization_info: dummy_event.serialization_info,
-            digest: sai,
-            data: event,
-        })
+        let event_len = encoded.len();
+        tmp_self.serialization_info.size = event_len;
+        let keri_event = tmp_self.compute_digest((&derivation).into(), format);
+        Ok(keri_event)
+
+        // let dummy_event = DummyEvent::dummy_event(event.clone(), format, &(&derivation).into())?;
+
+        // let sai = derivation.derive(&dummy_event.encode()?);
+        // Ok(Self {
+        //     serialization_info: dummy_event.serialization_info,
+        //     digest: sai,
+        //     data: event,
+        // })
     }
 
     pub fn encode(&self) -> Result<Vec<u8>, Error> {

--- a/keriox_core/src/event_message/msg.rs
+++ b/keriox_core/src/event_message/msg.rs
@@ -40,17 +40,14 @@ impl<T: Serialize + Clone, D: Serialize + Typeable<TypeTag = T> + Clone> TypedEv
     }
 
     pub fn check_digest(&self) -> Result<(), Error> {
-        let dummy = self.derivative(
+        let dummy = self.derivation_data(
             &(&self.get_digest().derivation).into(),
             &self.serialization_info.kind,
         );
-        let dummy = dummy.as_bytes().to_vec();
-        Ok(self
-            .get_digest()
+        self.get_digest()
             .verify_binding(&dummy)
             .then_some(())
-            .unwrap())
-        // .ok_or(Error::IncorrectDigest)
+            .ok_or(Error::IncorrectDigest)
     }
 
     pub fn new(
@@ -66,8 +63,7 @@ impl<T: Serialize + Clone, D: Serialize + Typeable<TypeTag = T> + Clone> TypedEv
             digest: None,
             data: event,
         };
-        let encoded = tmp_self.derivative(&(&derivation).into(), &format);
-        println!("In KeriEvent new: {}", encoded);
+        let encoded = tmp_self.derivation_data(&(&derivation).into(), &format);
 
         let event_len = encoded.len();
         tmp_self.serialization_info.size = event_len;

--- a/keriox_core/src/event_message/signature.rs
+++ b/keriox_core/src/event_message/signature.rs
@@ -85,7 +85,7 @@ pub fn signatures_into_groups(sigs: &[Signature]) -> Vec<Group> {
                     Signature::Transferable(SignerData::EventSeal(seal), sig) => trans_seal.push((
                         seal.prefix.into(),
                         seal.sn,
-                        (&seal.event_digest).into(),
+                        seal.event_digest.into(),
                         sig.into_iter().map(|sig| sig.into()).collect(),
                     )),
                     Signature::Transferable(SignerData::LastEstablishment(id), sig) => trans_last
@@ -207,7 +207,7 @@ impl Into<Group> for crate::event_message::signature::Signature {
                     }) => Group::TransIndexedSigGroups(vec![(
                         prefix.into(),
                         sn,
-                        (&event_digest).into(),
+                        event_digest.into(),
                         signatures,
                     )]),
                     crate::event_message::signature::SignerData::LastEstablishment(id) => {

--- a/keriox_core/src/event_message/signed_event_message.rs
+++ b/keriox_core/src/event_message/signed_event_message.rs
@@ -110,6 +110,7 @@ impl Op {
             #[cfg(feature = "mailbox")]
             // returns exchange message recipient id
             Op::Exchange(exn) => exn.exchange_message.data.data.get_prefix(),
+            _ => todo!(),
         }
     }
 }
@@ -270,13 +271,11 @@ pub mod tests {
 
     use cesrox::{parse, ParsedData};
 
+    #[cfg(feature = "query")]
+    use crate::error::Error;
     use crate::{
         actor::prelude::Message,
-        error::Error,
-        event_message::{
-            signature::Nontransferable,
-            signed_event_message::{Notice, Op},
-        },
+        event_message::{signature::Nontransferable, signed_event_message::Notice},
     };
 
     #[test]
@@ -370,8 +369,10 @@ pub mod tests {
         };
     }
 
+    #[cfg(feature = "mailbox")]
     #[test]
     fn test_deserialize_signed_exchange() -> Result<(), Error> {
+        use crate::event_message::signed_event_message::Op;
         let exn_event = br#"{"v":"KERI10JSON0002f1_","t":"exn","d":"EBLqTGJXK8ViUGXMOO8_LXbetpjJX8CY_SbA134RIZmf","dt":"2022-10-25T09:53:04.119676+00:00","r":"/fwd","q":{"pre":"EKYLUMmNPZeEs77Zvclf0bSN5IN-mLfLpx2ySb-HDlk4","topic":"multisig"},"a":{"v":"KERI10JSON000215_","t":"icp","d":"EC61gZ9lCKmHAS7U5ehUfEbGId5rcY0D7MirFZHDQcE2","i":"EC61gZ9lCKmHAS7U5ehUfEbGId5rcY0D7MirFZHDQcE2","s":"0","kt":"2","k":["DOZlWGPfDHLMf62zSFzE8thHmnQUOgA3_Y-KpOyF9ScG","DHGb2qY9WwZ1sBnC9Ip0F-M8QjTM27ftI-3jTGF9mc6K"],"nt":"2","n":["EBvD5VIVvf6NpP9GRmTqu_Cd1KN0RKrKNfPJ-uhIxurj","EHlpcaxffvtcpoUUMTc6tpqAVtb2qnOYVk_3HRsZ34PH"],"bt":"3","b":["BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha","BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM","BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX"],"c":[],"a":[]}}-HABEJccSRTfXYF6wrUVuenAIHzwcx3hJugeiJsEKmndi5q1-AABAAArUSuSpts5zDQ7CgPcy305IxhAG8lOjf-r_d5yYQXp18OD9No_gd2McOOjGWMfjyLVjDK529pQcbvNv9Uwc6gH-LAZ5AABAA-a-AABAABYHc_lpuYF3SPNWvyPjzek7yquw69Csc6pLv5vrXHkFAFDcwNNTVxq7ZpxpqOO0CAIS-9Qj1zMor-cwvMHAmkE"#;
 
         let parsed_exn = parse(exn_event).unwrap().1;

--- a/keriox_core/src/event_message/signed_event_message.rs
+++ b/keriox_core/src/event_message/signed_event_message.rs
@@ -110,7 +110,6 @@ impl Op {
             #[cfg(feature = "mailbox")]
             // returns exchange message recipient id
             Op::Exchange(exn) => exn.exchange_message.data.data.get_prefix(),
-            _ => todo!(),
         }
     }
 }

--- a/keriox_core/src/event_message/signed_event_message.rs
+++ b/keriox_core/src/event_message/signed_event_message.rs
@@ -166,8 +166,10 @@ impl Serialize for SignedEventMessage {
                 em.serialize_field("", &att_receipts)?;
             }
             if let Some(ref seal) = self.delegator_seal {
-                let att_seal =
-                    Group::SourceSealCouples(vec![(seal.sn.into(), (&seal.digest).into())]);
+                let att_seal = Group::SourceSealCouples(vec![(
+                    (&seal.sn).clone(),
+                    seal.digest.clone().into(),
+                )]);
                 em.serialize_field("", &att_seal.to_cesr_str())?;
             }
 

--- a/keriox_core/src/event_message/signed_event_message.rs
+++ b/keriox_core/src/event_message/signed_event_message.rs
@@ -108,7 +108,7 @@ impl Op {
             #[cfg(feature = "query")]
             Op::Query(qry) => qry.query.get_prefix(),
             #[cfg(feature = "mailbox")]
-            // returns exchange message receipient id
+            // returns exchange message recipient id
             Op::Exchange(exn) => exn.exchange_message.data.data.get_prefix(),
         }
     }

--- a/keriox_core/src/event_message/tests/test_utils.rs
+++ b/keriox_core/src/event_message/tests/test_utils.rs
@@ -115,7 +115,7 @@ fn test_update_identifier_state(
     // Check if state is updated correctly.
     assert_eq!(new_state.prefix, prefix.clone());
     assert_eq!(new_state.sn, state_data.sn);
-    assert_eq!(new_state.last_event_digest, event_msg.get_digest());
+    assert_eq!(new_state.last_event_digest, event_msg.digest()?);
     assert_eq!(new_state.current.public_keys.len(), 1);
     assert_eq!(new_state.current.public_keys[0], current_key_pref);
     assert_eq!(new_state.current.threshold, SignatureThreshold::Simple(1));
@@ -133,7 +133,7 @@ fn test_update_identifier_state(
         new_history.push(current_key_pref);
     }
     // Current event will be previous event for the next one, so return its hash.
-    let prev_event_hash = event_msg.get_digest();
+    let prev_event_hash = event_msg.digest()?;
     // Compute sn for next event.
     let next_sn = state_data.sn + 1;
 

--- a/keriox_core/src/prefix/mod.rs
+++ b/keriox_core/src/prefix/mod.rs
@@ -322,7 +322,8 @@ mod tests {
 
         // Test SelfAddressingIdentifier serialization.
         assert_eq!(
-            SelfAddressingIdentifier::new(HashFunctionCode::Blake3_256.into(), vec![0; 32]).to_str(),
+            SelfAddressingIdentifier::new(HashFunctionCode::Blake3_256.into(), vec![0; 32])
+                .to_str(),
             ["E".to_string(), "A".repeat(43)].join("")
         );
         assert_eq!(
@@ -344,7 +345,8 @@ mod tests {
             ["I".to_string(), "A".repeat(43)].join("")
         );
         assert_eq!(
-            SelfAddressingIdentifier::new(HashFunctionCode::Blake3_512.into(), vec![0; 64]).to_str(),
+            SelfAddressingIdentifier::new(HashFunctionCode::Blake3_512.into(), vec![0; 64])
+                .to_str(),
             ["0D".to_string(), "A".repeat(86)].join("")
         );
         assert_eq!(
@@ -352,7 +354,8 @@ mod tests {
             ["0E".to_string(), "A".repeat(86)].join("")
         );
         assert_eq!(
-            SelfAddressingIdentifier::new(HashFunctionCode::Blake2B512.into(), vec![0; 64]).to_str(),
+            SelfAddressingIdentifier::new(HashFunctionCode::Blake2B512.into(), vec![0; 64])
+                .to_str(),
             ["0F".to_string(), "A".repeat(86)].join("")
         );
         assert_eq!(

--- a/keriox_core/src/processor/event_storage.rs
+++ b/keriox_core/src/processor/event_storage.rs
@@ -85,7 +85,11 @@ impl EventStorage {
                             .get_nt_receipts(
                                 &event.signed_event_message.event_message.data.get_prefix(),
                                 event.signed_event_message.event_message.data.get_sn(),
-                                &event.signed_event_message.event_message.get_digest(),
+                                &event
+                                    .signed_event_message
+                                    .event_message
+                                    .digest()
+                                    .expect("Event with no digest"),
                             )
                             .unwrap()
                             .map(Notice::NontransferableRct);
@@ -219,12 +223,16 @@ impl EventStorage {
         } else {
             return Ok(None);
         }
-        let seal = last_est.map(|event| EventSeal {
-            prefix: event.event_message.data.get_prefix(),
-            sn: event.event_message.data.get_sn(),
-            event_digest: event.event_message.get_digest(),
-        });
-        Ok(seal)
+        if let Some(event) = last_est {
+            let event_digest = event.event_message.digest()?;
+            Ok(Some(EventSeal {
+                prefix: event.event_message.data.get_prefix(),
+                sn: event.event_message.data.get_sn(),
+                event_digest,
+            }))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Compute State for Prefix and sn

--- a/keriox_core/src/processor/mod.rs
+++ b/keriox_core/src/processor/mod.rs
@@ -119,7 +119,7 @@ impl EventProcessor {
                     let id = signed_event.event_message.data.get_prefix();
                     let receipt = Receipt::new(
                         SerializationFormats::JSON,
-                        signed_event.event_message.get_digest(),
+                        signed_event.event_message.digest()?,
                         id,
                         signed_event.event_message.data.get_sn(),
                     );

--- a/keriox_core/src/processor/processor_tests.rs
+++ b/keriox_core/src/processor/processor_tests.rs
@@ -176,14 +176,14 @@ fn test_process_delegated() -> Result<(), Error> {
     let parsed = parse(delegator_icp).unwrap().1;
     let msg = Message::try_from(parsed).unwrap();
     event_processor.process(&msg)?;
-    let delegator_prefix = "EA_SbBUZYwqLVlAAn14d6QUBQCSReJlZ755JqTgmRhXH".parse()?;
+    let delegator_prefix: IdentifierPrefix = "EA_SbBUZYwqLVlAAn14d6QUBQCSReJlZ755JqTgmRhXH".parse()?;
 
     // Delegated inception event.
     let dip_raw = br#"{"v":"KERI10JSON00015f_","t":"dip","d":"EHng2fV42DdKb5TLMIs6bbjFkPNmIdQ5mSFn6BTnySJj","i":"EHng2fV42DdKb5TLMIs6bbjFkPNmIdQ5mSFn6BTnySJj","s":"0","kt":"1","k":["DLitcfMnabnLt-PNCaXdVwX45wsG93Wd8eW9QiZrlKYQ"],"nt":"1","n":["EDjXvWdaNJx7pAIr72Va6JhHxc7Pf4ScYJG496ky8lK8"],"bt":"0","b":[],"c":[],"a":[],"di":"EA_SbBUZYwqLVlAAn14d6QUBQCSReJlZ755JqTgmRhXH"}-AABAABv6Q3s-1Tif-ksrx7ul9OKyOL_ZPHHp6lB9He4n6kswjm9VvHXzWB3O7RS2OQNWhx8bd3ycg9bWRPRrcKADoYC-GAB0AAAAAAAAAAAAAAAAAAAAAABEJtQndkvwnMpVGE5oVVbLWSCm-jLviGw1AOOkzBvNwsS"#;
     let parsed = parse(dip_raw).unwrap().1;
     let deserialized_dip = Message::try_from(parsed).unwrap();
 
-    let child_prefix = "EHng2fV42DdKb5TLMIs6bbjFkPNmIdQ5mSFn6BTnySJj".parse()?;
+    let child_prefix: IdentifierPrefix = "EHng2fV42DdKb5TLMIs6bbjFkPNmIdQ5mSFn6BTnySJj".parse()?;
 
     // Delegators's ixn event with delegating event seal.
     let delegator_ixn = br#"{"v":"KERI10JSON00013a_","t":"ixn","d":"EJtQndkvwnMpVGE5oVVbLWSCm-jLviGw1AOOkzBvNwsS","i":"EA_SbBUZYwqLVlAAn14d6QUBQCSReJlZ755JqTgmRhXH","s":"1","p":"EA_SbBUZYwqLVlAAn14d6QUBQCSReJlZ755JqTgmRhXH","a":[{"i":"EHng2fV42DdKb5TLMIs6bbjFkPNmIdQ5mSFn6BTnySJj","s":"0","d":"EHng2fV42DdKb5TLMIs6bbjFkPNmIdQ5mSFn6BTnySJj"}]}-AABAADFmoctrQkBbm47vuk7ejMbQ1y5vKD0Nfo8cqzbETZAlEPdbgVRSFta1-Bpv0y1RiDrCxa_0IOp906gYqDPXIwG"#;

--- a/keriox_core/src/processor/processor_tests.rs
+++ b/keriox_core/src/processor/processor_tests.rs
@@ -176,7 +176,8 @@ fn test_process_delegated() -> Result<(), Error> {
     let parsed = parse(delegator_icp).unwrap().1;
     let msg = Message::try_from(parsed).unwrap();
     event_processor.process(&msg)?;
-    let delegator_prefix: IdentifierPrefix = "EA_SbBUZYwqLVlAAn14d6QUBQCSReJlZ755JqTgmRhXH".parse()?;
+    let delegator_prefix: IdentifierPrefix =
+        "EA_SbBUZYwqLVlAAn14d6QUBQCSReJlZ755JqTgmRhXH".parse()?;
 
     // Delegated inception event.
     let dip_raw = br#"{"v":"KERI10JSON00015f_","t":"dip","d":"EHng2fV42DdKb5TLMIs6bbjFkPNmIdQ5mSFn6BTnySJj","i":"EHng2fV42DdKb5TLMIs6bbjFkPNmIdQ5mSFn6BTnySJj","s":"0","kt":"1","k":["DLitcfMnabnLt-PNCaXdVwX45wsG93Wd8eW9QiZrlKYQ"],"nt":"1","n":["EDjXvWdaNJx7pAIr72Va6JhHxc7Pf4ScYJG496ky8lK8"],"bt":"0","b":[],"c":[],"a":[],"di":"EA_SbBUZYwqLVlAAn14d6QUBQCSReJlZ755JqTgmRhXH"}-AABAABv6Q3s-1Tif-ksrx7ul9OKyOL_ZPHHp6lB9He4n6kswjm9VvHXzWB3O7RS2OQNWhx8bd3ycg9bWRPRrcKADoYC-GAB0AAAAAAAAAAAAAAAAAAAAAABEJtQndkvwnMpVGE5oVVbLWSCm-jLviGw1AOOkzBvNwsS"#;

--- a/keriox_core/src/processor/processor_tests.rs
+++ b/keriox_core/src/processor/processor_tests.rs
@@ -338,7 +338,7 @@ pub fn test_partial_rotation_simple_threshold() -> Result<(), Error> {
     // {"v":"KERI10JSON0001e7_","t":"icp","d":"EKkedrfoZz54Xsb_lGGdKTkYqNMf6TMrX1x57M1j0yi3","i":"EKkedrfoZz54Xsb_lGGdKTkYqNMf6TMrX1x57M1j0yi3","s":"0","kt":"1","k":["DErocgXD2RGSyvn3MObcx59jeOsEQhv2TqHirVkzrp0Q"],"nt":"2","n":["EIQsSW4KMrLzY1HQI9H_XxY6MyzhaFFXhG6fdBb5Wxta","EHuvLs1hmwxo4ImDoCpaAermYVQhiPsPDNaZsz4bcgko","EDJk5EEpC4-tQ7YDwBiKbpaZahh1QCyQOnZRF7p2i8k8","EAXfDjKvUFRj-IEB_o4y-Y_qeJAjYfZtOMD9e7vHNFss","EN8l6yJC2PxribTN0xfri6bLz34Qvj-x3cNwcV3DvT2m"],"bt":"0","b":[],"c":[],"a":[]}
 
     let id_prefix = icp.data.get_prefix();
-    let icp_digest = icp.get_digest();
+    let icp_digest = icp.digest()?;
     assert_eq!(
         id_prefix,
         IdentifierPrefix::SelfAddressing(icp_digest.clone())
@@ -381,7 +381,7 @@ pub fn test_partial_rotation_simple_threshold() -> Result<(), Error> {
         .with_next_threshold(&SignatureThreshold::Simple(4))
         .build()?;
 
-    let rot_digest = rotation.get_digest();
+    let rot_digest = rotation.digest()?;
 
     let signatures = current_signers
         .iter()
@@ -515,7 +515,7 @@ pub fn test_partial_rotation_weighted_threshold() -> Result<(), Error> {
         .unwrap();
 
     let id_prefix = icp.data.get_prefix();
-    let icp_digest = icp.get_digest();
+    let icp_digest = icp.digest()?;
     assert_eq!(
         id_prefix,
         IdentifierPrefix::SelfAddressing(icp_digest.clone())
@@ -569,7 +569,7 @@ pub fn test_partial_rotation_weighted_threshold() -> Result<(), Error> {
         ]))
         .build()?;
 
-    let rot_digest = rotation.get_digest();
+    let rot_digest = rotation.digest()?;
 
     let signatures = current_signers
         .iter()
@@ -693,7 +693,7 @@ pub fn test_reserve_rotation() -> Result<(), Error> {
         .unwrap();
 
     let id_prefix = icp.data.get_prefix();
-    let icp_digest = icp.get_digest();
+    let icp_digest = icp.digest()?;
     assert_eq!(
         id_prefix,
         IdentifierPrefix::SelfAddressing(icp_digest.clone())
@@ -746,7 +746,7 @@ pub fn test_reserve_rotation() -> Result<(), Error> {
         ]))
         .build()?;
 
-    let rot_digest = rotation.get_digest();
+    let rot_digest = rotation.digest()?;
 
     let signatures = current_signers
         .iter()
@@ -875,7 +875,7 @@ pub fn test_custorial_rotation() -> Result<(), Error> {
         .unwrap();
 
     let id_prefix = icp.data.get_prefix();
-    let icp_digest = icp.get_digest();
+    let icp_digest = icp.digest()?;
     assert_eq!(
         id_prefix,
         IdentifierPrefix::SelfAddressing(icp_digest.clone())

--- a/keriox_core/src/processor/validator.rs
+++ b/keriox_core/src/processor/validator.rs
@@ -85,7 +85,7 @@ impl EventValidator {
             // check if there are enough receipts and escrow
             let sn = signed_event.event_message.data.get_sn();
             let prefix = &signed_event.event_message.data.get_prefix();
-            let digest = &signed_event.event_message.get_digest();
+            let digest = &signed_event.event_message.digest()?;
 
             let (mut couples, mut indexed) = (vec![], vec![]);
             match self.event_storage.get_nt_receipts(prefix, sn, digest)? {
@@ -460,7 +460,7 @@ fn test_validate_seal() -> Result<(), Error> {
     let parsed = parse(dip_raw).unwrap().1;
     let msg = Message::try_from(parsed).unwrap();
     if let Message::Notice(Notice::Event(dip)) = msg {
-        let delegated_event_digest = dip.event_message.get_digest();
+        let delegated_event_digest = dip.event_message.digest()?;
         // Construct delegating seal.
         let seal = EventSeal {
             prefix: delegator_id,

--- a/keriox_core/tests/test_processing.rs
+++ b/keriox_core/tests/test_processing.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "query")]
 use std::sync::Arc;
 
+#[cfg(feature = "query")]
 use keri::{
     actor::{parse_event_stream, prelude::*},
     database::{escrow::EscrowDb, SledEventDatabase},
@@ -11,6 +13,7 @@ use keri::{
     },
 };
 
+#[cfg(feature = "query")]
 #[test]
 pub fn test_ksn_query() -> Result<(), Box<dyn std::error::Error>> {
     use keri::event_message::signed_event_message::Message;

--- a/support/teliox/Cargo.toml
+++ b/support/teliox/Cargo.toml
@@ -11,9 +11,9 @@ license = "EUPL-1.2"
 
 [dependencies]
 keri = {path = "../../keriox_core"}
-said = { git = "https://github.com/THCLab/cesrox", branch = "sad" }
-cesrox = { git = "https://github.com/THCLab/cesrox", branch = "sad" }
-version = { git = "https://github.com/THCLab/cesrox", branch = "sad" }
+said = { git = "https://github.com/THCLab/cesrox", tag = "v0.1.4" }
+cesrox = { git = "https://github.com/THCLab/cesrox", tag = "v0.1.4" }
+version = { git = "https://github.com/THCLab/cesrox", tag = "v0.1.4" }
 base64 = "0.13.0"
 serde = "1.0"
 serde_json = "1.0"

--- a/support/teliox/Cargo.toml
+++ b/support/teliox/Cargo.toml
@@ -11,9 +11,9 @@ license = "EUPL-1.2"
 
 [dependencies]
 keri = {path = "../../keriox_core"}
-said = { git = "https://github.com/THCLab/cesrox" }
-cesrox = { git = "https://github.com/THCLab/cesrox" }
-version = { git = "https://github.com/THCLab/cesrox" }
+said = { git = "https://github.com/THCLab/cesrox", branch = "sad" }
+cesrox = { git = "https://github.com/THCLab/cesrox", branch = "sad" }
+version = { git = "https://github.com/THCLab/cesrox", branch = "sad" }
 base64 = "0.13.0"
 serde = "1.0"
 serde_json = "1.0"

--- a/support/teliox/src/event/mod.rs
+++ b/support/teliox/src/event/mod.rs
@@ -8,7 +8,7 @@ pub mod manager_event;
 pub mod vc_event;
 pub mod verifiable_event;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Event {
     Management(ManagerTelEventMessage),
     Vc(VCEventMessage),

--- a/support/teliox/src/event/vc_event.rs
+++ b/support/teliox/src/event/vc_event.rs
@@ -2,16 +2,12 @@ use crate::error::Error;
 use chrono::{DateTime, FixedOffset, SecondsFormat, Utc};
 use keri::{
     event::sections::seal::EventSeal,
-    event_message::{
-        msg::{KeriEvent, TypedEvent},
-        Typeable,
-    },
+    event_message::{msg::TypedEvent, Typeable},
     prefix::IdentifierPrefix,
 };
 use said::{derivation::HashFunctionCode, SelfAddressingIdentifier};
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{de, Deserialize, Serialize, Serializer};
 use serde_hex::{Compact, SerHex};
-use serde_json::Value;
 use version::serialization_info::SerializationFormats;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -129,43 +125,13 @@ impl VCEvent {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged, rename_all = "lowercase")]
 pub enum VCEventType {
-    Iss(SimpleIssuance),
     Rev(SimpleRevocation),
+    Iss(SimpleIssuance),
     Bis(Issuance),
     Brv(Revocation),
-}
-
-impl<'de> Deserialize<'de> for VCEventType {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        // Helper struct for adding tag to properly deserialize 't' field
-        #[derive(Deserialize, Debug)]
-        struct EventType {
-            t: TelEventType,
-        }
-
-        let v = Value::deserialize(deserializer)?;
-        let m = EventType::deserialize(&v).map_err(de::Error::custom)?;
-        match m.t {
-            TelEventType::Iss => Ok(VCEventType::Iss(
-                SimpleIssuance::deserialize(&v).map_err(de::Error::custom)?,
-            )),
-            TelEventType::Rev => Ok(VCEventType::Rev(
-                SimpleRevocation::deserialize(&v).map_err(de::Error::custom)?,
-            )),
-            TelEventType::Bis => Ok(VCEventType::Bis(
-                Issuance::deserialize(&v).map_err(de::Error::custom)?,
-            )),
-            TelEventType::Brv => Ok(VCEventType::Brv(
-                Revocation::deserialize(&v).map_err(de::Error::custom)?,
-            )),
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/support/teliox/src/event/vc_event.rs
+++ b/support/teliox/src/event/vc_event.rs
@@ -2,7 +2,10 @@ use crate::error::Error;
 use chrono::{DateTime, FixedOffset, SecondsFormat, Utc};
 use keri::{
     event::sections::seal::EventSeal,
-    event_message::{msg::KeriEvent, Typeable},
+    event_message::{
+        msg::{KeriEvent, TypedEvent},
+        Typeable,
+    },
     prefix::IdentifierPrefix,
 };
 use said::{derivation::HashFunctionCode, SelfAddressingIdentifier};
@@ -69,7 +72,7 @@ impl From<TimestampedVCEvent> for VCEvent {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum TelEventType {
     Iss,
@@ -78,7 +81,7 @@ pub enum TelEventType {
     Brv,
 }
 
-pub type VCEventMessage = KeriEvent<TimestampedVCEvent>;
+pub type VCEventMessage = TypedEvent<TelEventType, TimestampedVCEvent>;
 impl Typeable for VCEvent {
     type TypeTag = TelEventType;
     fn get_type(&self) -> TelEventType {
@@ -118,7 +121,11 @@ impl VCEvent {
         derivation: HashFunctionCode,
     ) -> Result<VCEventMessage, Error> {
         let timestamped = TimestampedVCEvent::new(self);
-        Ok(KeriEvent::new(format, derivation.into(), timestamped)?)
+        Ok(TypedEvent::<TelEventType, TimestampedVCEvent>::new(
+            format,
+            derivation.into(),
+            timestamped,
+        )?)
     }
 }
 

--- a/support/teliox/src/event/verifiable_event.rs
+++ b/support/teliox/src/event/verifiable_event.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use super::Event;
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct VerifiableEvent {
     pub event: Event,
     pub seal: AttachedSourceSeal,

--- a/support/teliox/src/processor/mod.rs
+++ b/support/teliox/src/processor/mod.rs
@@ -170,7 +170,10 @@ mod tests {
         // check if vcp event is in db.
         let man_event_from_db = processor.get_management_event_at_sn(&management_tel_prefix, 0)?;
         assert!(man_event_from_db.is_some());
-        assert_eq!(man_event_from_db.unwrap(), verifiable_vcp);
+        assert_eq!(
+            man_event_from_db.unwrap().serialize().unwrap(),
+            verifiable_vcp.serialize().unwrap()
+        );
 
         // create issue event
         let vc_prefix = IdentifierPrefix::SelfAddressing(message_id.clone());
@@ -234,7 +237,10 @@ mod tests {
         // check if vrt event is in db.
         let man_event_from_db = processor.get_management_event_at_sn(&management_tel_prefix, 1)?;
         assert!(man_event_from_db.is_some());
-        assert_eq!(man_event_from_db.unwrap(), verifiable_vrt);
+        assert_eq!(
+            man_event_from_db.unwrap().serialize().unwrap(),
+            verifiable_vrt.serialize().unwrap()
+        );
 
         Ok(())
     }

--- a/support/teliox/src/processor/mod.rs
+++ b/support/teliox/src/processor/mod.rs
@@ -141,7 +141,8 @@ mod tests {
 
         // Setup test data.
         let message = "some message";
-        let message_id = HashFunction::from(HashFunctionCode::Blake3_256).derive(message.as_bytes());
+        let message_id =
+            HashFunction::from(HashFunctionCode::Blake3_256).derive(message.as_bytes());
         let issuer_prefix: IdentifierPrefix = "EaKJ0FoLxO1TYmyuprguKO7kJ7Hbn0m0Wuk5aMtSrMtY"
             .parse()
             .unwrap();

--- a/support/teliox/src/seal/mod.rs
+++ b/support/teliox/src/seal/mod.rs
@@ -1,5 +1,5 @@
 use base64::URL_SAFE;
-use keri::prefix::CesrPrimitive;
+use cesrox::primitives::CesrPrimitive;
 use said::SelfAddressingIdentifier;
 use serde::{Deserialize, Serialize};
 

--- a/support/teliox/src/state/mod.rs
+++ b/support/teliox/src/state/mod.rs
@@ -44,7 +44,7 @@ impl ManagerTelState {
                     Ok(ManagerTelState {
                         prefix: event_content.prefix.to_owned(),
                         sn: 0,
-                        last: event.get_digest(),
+                        last: event.digest()?,
                         issuer: vcp.issuer_id.clone(),
                         backers,
                     })
@@ -66,7 +66,7 @@ impl ManagerTelState {
                                 Ok(ManagerTelState {
                                     prefix: self.prefix.to_owned(),
                                     sn: self.sn + 1,
-                                    last: event.get_digest(),
+                                    last: event.digest()?,
                                     backers: Some(new_backers),
                                     issuer: self.issuer.clone(),
                                 })

--- a/support/teliox/src/state/vc_state.rs
+++ b/support/teliox/src/state/vc_state.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum TelState {
-    NotIsuued,
+    NotIssued,
     Issued(SelfAddressingIdentifier),
     Revoked,
 }
@@ -17,9 +17,9 @@ impl TelState {
         let event_content = event.data.data.clone();
         match event_content.event_type {
             VCEventType::Bis(_iss) => match self {
-                TelState::NotIsuued => {
+                TelState::NotIssued => {
                     if event_content.sn == 0 {
-                        Ok(TelState::Issued(event.get_digest()))
+                        Ok(TelState::Issued(event.digest()?))
                     } else {
                         Err(Error::Generic("Wrong sn".into()))
                     }
@@ -37,7 +37,7 @@ impl TelState {
                 _ => Err(Error::Generic("Wrong state".into())),
             },
             VCEventType::Iss(_iss) => match self {
-                TelState::NotIsuued => Ok(TelState::Issued(event.get_digest())),
+                TelState::NotIssued => Ok(TelState::Issued(event.digest()?)),
                 _ => Err(Error::Generic("Wrong state".into())),
             },
             VCEventType::Rev(rev) => match self {
@@ -56,7 +56,7 @@ impl TelState {
 
 impl Default for TelState {
     fn default() -> Self {
-        TelState::NotIsuued
+        TelState::NotIssued
     }
 }
 

--- a/support/teliox/src/tel/event_generator.rs
+++ b/support/teliox/src/tel/event_generator.rs
@@ -30,7 +30,11 @@ pub fn make_inception_event(
     Ok(Event::Management(
         event_type
             .incept_self_addressing(
-                &HashFunction::from(derivation.unwrap_or(&HashFunctionCode::Blake3_256).to_owned()),
+                &HashFunction::from(
+                    derivation
+                        .unwrap_or(&HashFunctionCode::Blake3_256)
+                        .to_owned(),
+                ),
                 serialization_format
                     .unwrap_or(&SerializationFormats::JSON)
                     .to_owned(),


### PR DESCRIPTION
Changes: 
- use derive macro for implementing `SAD` trait,
- update event parsing tests. 