### PR TITLE
feat: abstract oobi manager and add postgres backend

### DIFF
--- a/components/controller/src/error.rs
+++ b/components/controller/src/error.rs
@@ -1,7 +1,7 @@
 use keri_core::{
     actor::prelude::VersionError, database::redb::RedbError,
-    event_message::cesr_adapter::ParseError, oobi::Scheme, prefix::IdentifierPrefix,
-    processor::validator::VerificationError,
+    event_message::cesr_adapter::ParseError, oobi::Scheme, oobi::error::OobiError,
+    prefix::IdentifierPrefix, processor::validator::VerificationError,
 };
 use thiserror::Error;
 
@@ -58,9 +58,18 @@ pub enum ControllerError {
     #[error("Error: {0}")]
     OtherError(String),
 
+    #[error("Oobi error: {0}")]
+    OobiError(String),
+
     #[error(transparent)]
     Mechanic(#[from] MechanicsError),
 
     #[error("Watcher response error: {0}")]
     WatcherResponseError(#[from] WatcherResponseError),
+}
+
+impl From<OobiError> for ControllerError {
+    fn from(e: OobiError) -> Self {
+        ControllerError::OobiError(e.to_string())
+    }
 }

--- a/components/controller/src/known_events.rs
+++ b/components/controller/src/known_events.rs
@@ -42,8 +42,14 @@ use crate::identifier::mechanics::MechanicsError;
 pub enum OobiRetrieveError {
     #[error("No oobi for {0} identifier")]
     MissingOobi(IdentifierPrefix, Option<Scheme>),
-    #[error(transparent)]
-    DbError(#[from] RedbError),
+    #[error("Database error: {0}")]
+    DbError(String),
+}
+
+impl From<keri_core::oobi::error::OobiError> for OobiRetrieveError {
+    fn from(e: keri_core::oobi::error::OobiError) -> Self {
+        OobiRetrieveError::DbError(e.to_string())
+    }
 }
 
 pub struct KnownEvents {
@@ -62,7 +68,7 @@ impl KnownEvents {
             Arc::new(RedbDatabase::new(&path)?)
         };
 
-        let oobi_manager = OobiManager::new(event_database.clone());
+        let oobi_manager = OobiManager::new(event_database.clone())?;
 
         let (
             mut notification_bus,

--- a/components/watcher/src/watcher/watcher_data.rs
+++ b/components/watcher/src/watcher/watcher_data.rs
@@ -112,7 +112,7 @@ impl WatcherData {
         let prefix = BasicPrefix::Ed25519NT(signer.public_key()); // watcher uses non transferable key
         let processor = BasicProcessor::new(events_db.clone(), Some(notification_bus));
 
-        let storage = Arc::new(EventStorage::new(events_db));
+        let storage = Arc::new(EventStorage::new_redb(events_db));
 
         // construct witness loc scheme oobi
         let loc_scheme = LocationScheme::new(

--- a/components/watcher/src/watcher/watcher_data.rs
+++ b/components/watcher/src/watcher/watcher_data.rs
@@ -3,8 +3,8 @@ use std::{fs::File, sync::Arc};
 use futures::future::join_all;
 use itertools::Itertools;
 use keri_core::actor::possible_response::PossibleResponse;
-use keri_core::database::redb::RedbError;
 use keri_core::error::Error;
+use keri_core::oobi::error::OobiError;
 use keri_core::oobi::LocationScheme;
 use keri_core::prefix::{BasicPrefix, IdentifierPrefix, SelfSigningPrefix};
 use keri_core::processor::escrow::default_escrow_bus;
@@ -97,7 +97,7 @@ impl WatcherData {
             Arc::new(RedbDatabase::new(&path).unwrap())
         };
 
-        let oobi_manager = OobiManager::new(events_db.clone());
+        let oobi_manager = OobiManager::new(events_db.clone())?;
 
         let (mut notification_bus, _) = default_escrow_bus(events_db.clone(), escrow_config);
         let reply_escrow = Arc::new(ReplyEscrow::new(events_db.clone()));
@@ -529,7 +529,7 @@ impl WatcherData {
     }
 
     /// Query roles in oobi manager to check if controller with given ID is allowed to communicate with us.
-    fn check_role(&self, cid: &IdentifierPrefix) -> Result<bool, RedbError> {
+    fn check_role(&self, cid: &IdentifierPrefix) -> Result<bool, OobiError> {
         Ok(self
             .oobi_manager
             .get_end_role(cid, Role::Watcher)?

--- a/components/witness/src/tests.rs
+++ b/components/witness/src/tests.rs
@@ -99,7 +99,7 @@ fn test_not_fully_witnessed() -> Result<(), Error> {
             let not = Notice::Event(inception_event.clone());
             w.process_notice(not).unwrap();
             w.event_storage
-                .mailbox_data
+                .mailbox_data.as_ref().unwrap()
                 .get_mailbox_receipts(controller.prefix(), 0)
                 .into_iter()
                 .flatten()
@@ -185,7 +185,7 @@ fn test_not_fully_witnessed() -> Result<(), Error> {
     // first_witness.respond(signer_arc.clone())?;
     let first_receipt = first_witness
         .event_storage
-        .mailbox_data
+        .mailbox_data.as_ref().unwrap()
         .get_mailbox_receipts(controller.prefix(), 0)
         .unwrap()
         .map(Notice::NontransferableRct)
@@ -280,7 +280,7 @@ fn test_qry_rpy() -> Result<(), ActorError> {
     // send receipts to alice
     let receipt_to_alice = witness
         .event_storage
-        .mailbox_data
+        .mailbox_data.as_ref().unwrap()
         .get_mailbox_receipts(alice.prefix(), 0)
         .unwrap()
         .map(Notice::NontransferableRct)

--- a/components/witness/src/witness.rs
+++ b/components/witness/src/witness.rs
@@ -86,7 +86,7 @@ impl Notifier for WitnessReceiptGenerator {
 
 impl WitnessReceiptGenerator {
     pub fn new(signer: Arc<Signer>, events_db: Arc<RedbDatabase>) -> Self {
-        let storage = EventStorage::new(events_db.clone());
+        let storage = EventStorage::new_redb(events_db.clone());
         let prefix = BasicPrefix::Ed25519NT(signer.public_key());
         Self {
             prefix,
@@ -172,7 +172,7 @@ impl Witness {
         let events_db =
             Arc::new(RedbDatabase::new(&events_database_path).map_err(|_| Error::DbError)?);
         let mut witness_processor = WitnessProcessor::new(events_db.clone(), escrow_config);
-        let event_storage = Arc::new(EventStorage::new(events_db.clone()));
+        let event_storage = Arc::new(EventStorage::new_redb(events_db.clone()));
 
         let receipt_generator = Arc::new(WitnessReceiptGenerator::new(
             signer.clone(),

--- a/components/witness/src/witness.rs
+++ b/components/witness/src/witness.rs
@@ -137,6 +137,12 @@ impl From<RedbError> for WitnessError {
     }
 }
 
+impl From<keri_core::oobi::error::OobiError> for WitnessError {
+    fn from(err: keri_core::oobi::error::OobiError) -> Self {
+        WitnessError::DatabaseError(err.to_string())
+    }
+}
+
 pub struct Witness {
     pub address: Url,
     pub prefix: BasicPrefix,
@@ -217,7 +223,7 @@ impl Witness {
             signer,
             event_storage,
             receipt_generator,
-            oobi_manager: OobiManager::new(events_db.clone()),
+            oobi_manager: OobiManager::new(events_db.clone())?,
             tel,
         })
     }

--- a/keriox_core/Cargo.toml
+++ b/keriox_core/Cargo.toml
@@ -13,11 +13,12 @@ repository.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = []
+default = ["storage-redb"]
+storage-redb = ["redb"]
 query = ["serde_cbor"]
 oobi = ["url", "strum_macros", "strum"]
-oobi-manager = ["oobi", "query", "reqwest", "async-trait", "serde_cbor"]
-mailbox = ["query", "serde_cbor"]
+oobi-manager = ["oobi", "query", "storage-redb", "reqwest", "async-trait", "serde_cbor"]
+mailbox = ["query", "storage-redb", "serde_cbor"]
 
 [dependencies]
 bytes = "1.3.0"
@@ -43,7 +44,7 @@ chrono = { version = "0.4.18", features = ["serde"] }
 arrayref = "0.3.6"
 zeroize = "1.3.0"
 fraction = { version = "0.9", features = ["with-serde-support"] }
-redb = "2.3.0"
+redb = { version = "2.3.0", optional = true }
 
 # oobis dependecies
 async-trait = { version = "0.1.57", optional = true }

--- a/keriox_core/Cargo.toml
+++ b/keriox_core/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = ["storage-redb"]
 storage-redb = ["redb"]
+storage-postgres = ["sqlx", "async-std"]
 query = ["serde_cbor"]
 oobi = ["url", "strum_macros", "strum"]
 oobi-manager = ["oobi", "query", "storage-redb", "reqwest", "async-trait", "serde_cbor"]
@@ -45,6 +46,10 @@ arrayref = "0.3.6"
 zeroize = "1.3.0"
 fraction = { version = "0.9", features = ["with-serde-support"] }
 redb = { version = "2.3.0", optional = true }
+
+# postgres db deps
+sqlx = { version = "0.8", features = ["runtime-async-std", "postgres"], optional = true }
+async-std = { version = "1", features = ["attributes"], optional = true }
 
 # oobis dependecies
 async-trait = { version = "0.1.57", optional = true }

--- a/keriox_core/src/actor/error.rs
+++ b/keriox_core/src/actor/error.rs
@@ -1,5 +1,6 @@
 use http::StatusCode;
 
+#[cfg(feature = "storage-redb")]
 use crate::database::redb::RedbError;
 use crate::event_message::cesr_adapter::ParseError;
 use crate::keys::KeysError;
@@ -74,6 +75,7 @@ impl From<VersionError> for ActorError {
     }
 }
 
+#[cfg(feature = "storage-redb")]
 impl From<RedbError> for ActorError {
     fn from(err: RedbError) -> Self {
         ActorError::DbError(err.to_string())

--- a/keriox_core/src/actor/mod.rs
+++ b/keriox_core/src/actor/mod.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "oobi-manager")]
-use crate::oobi_manager::OobiManager;
+use crate::oobi_manager::{storage::OobiStorageBackend, OobiManager};
 #[cfg(feature = "query")]
 use crate::{
     database::EventDatabase,
@@ -91,9 +91,9 @@ pub fn process_notice<P: Processor>(msg: Notice, processor: &P) -> Result<(), Er
 }
 
 #[cfg(feature = "query")]
-pub fn process_reply<P: Processor>(
+pub fn process_reply<P: Processor, #[cfg(feature = "oobi-manager")] S: OobiStorageBackend>(
     sr: SignedReply,
-    #[cfg(feature = "oobi-manager")] oobi_manager: &OobiManager,
+    #[cfg(feature = "oobi-manager")] oobi_manager: &OobiManager<S>,
     processor: &P,
     event_storage: &EventStorage<P::Database>,
 ) -> Result<(), Error> {
@@ -108,9 +108,9 @@ pub fn process_reply<P: Processor>(
 }
 
 #[cfg(feature = "oobi-manager")]
-pub fn process_signed_oobi<D: EventDatabase + 'static>(
+pub fn process_signed_oobi<D: EventDatabase + 'static, S: OobiStorageBackend>(
     signed_oobi: &SignedReply,
-    oobi_manager: &OobiManager,
+    oobi_manager: &OobiManager<S>,
     event_storage: &EventStorage<D>,
 ) -> Result<(), Error> {
     use crate::processor::validator::EventValidator;

--- a/keriox_core/src/actor/simple_controller.rs
+++ b/keriox_core/src/actor/simple_controller.rs
@@ -3,8 +3,10 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+#[cfg(feature = "storage-redb")]
+use crate::database::redb::RedbDatabase;
 use crate::{
-    database::{redb::RedbDatabase, EscrowCreator, EventDatabase},
+    database::{EscrowCreator, EventDatabase},
     processor::escrow::{
         maybe_out_of_order_escrow::MaybeOutOfOrderEscrow,
         partially_witnessed_escrow::PartiallyWitnessedEscrow,
@@ -72,6 +74,7 @@ pub struct SimpleController<K: KeyManager + 'static, D: EventDatabase + EscrowCr
 }
 
 // impl<K: KeyManager, D: EventDatabase + Send + Sync + 'static> SimpleController<K, D> {
+#[cfg(feature = "storage-redb")]
 impl<K: KeyManager> SimpleController<K, RedbDatabase> {
     // incept a state and keys
     pub fn new(

--- a/keriox_core/src/actor/simple_controller.rs
+++ b/keriox_core/src/actor/simple_controller.rs
@@ -89,7 +89,7 @@ impl<K: KeyManager> SimpleController<K, RedbDatabase> {
         Ok(SimpleController {
             prefix: IdentifierPrefix::default(),
             key_manager,
-            oobi_manager: OobiManager::new(event_db.clone()),
+            oobi_manager: OobiManager::new(event_db.clone())?,
             processor,
             storage: EventStorage::new(event_db.clone()),
             groups: vec![],

--- a/keriox_core/src/database/memory.rs
+++ b/keriox_core/src/database/memory.rs
@@ -1,0 +1,650 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+use said::SelfAddressingIdentifier;
+
+#[cfg(feature = "query")]
+use crate::query::reply_event::SignedReply;
+use crate::{
+    database::{
+        timestamped::{Timestamped, TimestampedSignedEventMessage},
+        EscrowCreator, EscrowDatabase, EventDatabase, LogDatabase, QueryParameters,
+        SequencedEventDatabase,
+    },
+    error::Error,
+    event::KeyEvent,
+    event_message::{
+        msg::KeriEvent,
+        signature::{Nontransferable, Transferable},
+        signed_event_message::{
+            SignedEventMessage, SignedNontransferableReceipt, SignedTransferableReceipt,
+        },
+    },
+    prefix::{IdentifierPrefix, IndexedSignature},
+    state::IdentifierState,
+};
+
+/// In-memory implementation of EventDatabase for testing and validation.
+pub struct MemoryDatabase {
+    /// Events stored by identifier prefix, ordered by sn
+    events: RwLock<HashMap<IdentifierPrefix, Vec<TimestampedSignedEventMessage>>>,
+    /// Key state per identifier
+    states: RwLock<HashMap<IdentifierPrefix, IdentifierState>>,
+    /// Transferable receipts by (id, sn)
+    receipts_t: RwLock<HashMap<(IdentifierPrefix, u64), Vec<Transferable>>>,
+    /// Non-transferable receipts by (id, sn)
+    receipts_nt: RwLock<HashMap<(IdentifierPrefix, u64), Vec<SignedNontransferableReceipt>>>,
+    /// Log database
+    log_db: Arc<MemoryLogDatabase>,
+    /// Escrow counter for creating unique table names
+    escrow_db: Arc<RwLock<HashMap<&'static str, Arc<MemorySequencedEventDb>>>>,
+    #[cfg(feature = "query")]
+    replies: RwLock<HashMap<(IdentifierPrefix, IdentifierPrefix), SignedReply>>,
+}
+
+impl MemoryDatabase {
+    pub fn new() -> Self {
+        Self {
+            events: RwLock::new(HashMap::new()),
+            states: RwLock::new(HashMap::new()),
+            receipts_t: RwLock::new(HashMap::new()),
+            receipts_nt: RwLock::new(HashMap::new()),
+            log_db: Arc::new(MemoryLogDatabase::new()),
+            escrow_db: Arc::new(RwLock::new(HashMap::new())),
+            #[cfg(feature = "query")]
+            replies: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl EventDatabase for MemoryDatabase {
+    type Error = Error;
+    type LogDatabaseType = MemoryLogDatabase;
+
+    fn get_log_db(&self) -> Arc<Self::LogDatabaseType> {
+        self.log_db.clone()
+    }
+
+    fn add_kel_finalized_event(
+        &self,
+        event: SignedEventMessage,
+        id: &IdentifierPrefix,
+    ) -> Result<(), Self::Error> {
+        // Update key state
+        let current_state = self
+            .states
+            .read()
+            .unwrap()
+            .get(id)
+            .cloned()
+            .unwrap_or_default();
+        let new_state = current_state.apply(&event.event_message)?;
+        self.states.write().unwrap().insert(id.clone(), new_state);
+
+        // Log the event
+        self.log_db.log_event_internal(&event);
+
+        // Store in KEL
+        let timestamped = Timestamped::new(event);
+        self.events
+            .write()
+            .unwrap()
+            .entry(id.clone())
+            .or_default()
+            .push(timestamped);
+
+        Ok(())
+    }
+
+    fn add_receipt_t(
+        &self,
+        receipt: SignedTransferableReceipt,
+        id: &IdentifierPrefix,
+    ) -> Result<(), Self::Error> {
+        let sn = receipt.body.sn;
+        let transferable = Transferable::Seal(receipt.validator_seal, receipt.signatures);
+        self.receipts_t
+            .write()
+            .unwrap()
+            .entry((id.clone(), sn))
+            .or_default()
+            .push(transferable);
+        Ok(())
+    }
+
+    fn add_receipt_nt(
+        &self,
+        receipt: SignedNontransferableReceipt,
+        id: &IdentifierPrefix,
+    ) -> Result<(), Self::Error> {
+        let sn = receipt.body.sn;
+        self.receipts_nt
+            .write()
+            .unwrap()
+            .entry((id.clone(), sn))
+            .or_default()
+            .push(receipt);
+        Ok(())
+    }
+
+    fn get_key_state(&self, id: &IdentifierPrefix) -> Option<IdentifierState> {
+        self.states.read().unwrap().get(id).cloned()
+    }
+
+    fn get_kel_finalized_events(
+        &self,
+        params: QueryParameters,
+    ) -> Option<impl DoubleEndedIterator<Item = TimestampedSignedEventMessage>> {
+        let events = self.events.read().unwrap();
+        match params {
+            QueryParameters::All { id } => {
+                events.get(id).cloned().map(|v| v.into_iter())
+            }
+            QueryParameters::BySn { ref id, sn } => {
+                events.get(id).map(|evts| {
+                    evts.iter()
+                        .filter(move |e| e.signed_event_message.event_message.data.get_sn() == sn)
+                        .cloned()
+                        .collect::<Vec<_>>()
+                        .into_iter()
+                })
+            }
+            QueryParameters::Range {
+                ref id,
+                start,
+                limit,
+            } => events.get(id).map(|evts| {
+                evts.iter()
+                    .filter(move |e| {
+                        let sn = e.signed_event_message.event_message.data.get_sn();
+                        sn >= start && sn < start + limit
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .into_iter()
+            }),
+        }
+    }
+
+    fn get_receipts_t(
+        &self,
+        params: QueryParameters,
+    ) -> Option<impl DoubleEndedIterator<Item = Transferable>> {
+        let receipts = self.receipts_t.read().unwrap();
+        match params {
+            QueryParameters::BySn { ref id, sn } => {
+                receipts.get(&(id.clone(), sn)).cloned().map(|v| v.into_iter())
+            }
+            _ => None,
+        }
+    }
+
+    fn get_receipts_nt(
+        &self,
+        params: QueryParameters,
+    ) -> Option<impl DoubleEndedIterator<Item = SignedNontransferableReceipt>> {
+        let receipts = self.receipts_nt.read().unwrap();
+        match params {
+            QueryParameters::BySn { ref id, sn } => {
+                receipts.get(&(id.clone(), sn)).cloned().map(|v| v.into_iter())
+            }
+            _ => None,
+        }
+    }
+
+    fn accept_to_kel(&self, _event: &KeriEvent<KeyEvent>) -> Result<(), Self::Error> {
+        // In redb, this saves the event to KEL tables. For memory, events
+        // are already in the events map from add_kel_finalized_event.
+        Ok(())
+    }
+
+    #[cfg(feature = "query")]
+    fn save_reply(&self, reply: SignedReply) -> Result<(), Self::Error> {
+        let id = reply.reply.get_prefix();
+        let signer = reply
+            .signature
+            .get_signer()
+            .ok_or_else(|| Error::SemanticError("Missing signer".into()))?;
+        self.replies
+            .write()
+            .unwrap()
+            .insert((id, signer), reply);
+        Ok(())
+    }
+
+    #[cfg(feature = "query")]
+    fn get_reply(
+        &self,
+        id: &IdentifierPrefix,
+        from_who: &IdentifierPrefix,
+    ) -> Option<SignedReply> {
+        self.replies
+            .read()
+            .unwrap()
+            .get(&(id.clone(), from_who.clone()))
+            .cloned()
+    }
+}
+
+/// In-memory log database for storing events by digest.
+pub struct MemoryLogDatabase {
+    events: RwLock<HashMap<SelfAddressingIdentifier, TimestampedSignedEventMessage>>,
+    signatures: RwLock<HashMap<SelfAddressingIdentifier, Vec<IndexedSignature>>>,
+    nontrans_couplets: RwLock<HashMap<SelfAddressingIdentifier, Vec<Nontransferable>>>,
+    trans_receipts: RwLock<HashMap<SelfAddressingIdentifier, Vec<Transferable>>>,
+}
+
+impl MemoryLogDatabase {
+    pub fn new() -> Self {
+        Self {
+            events: RwLock::new(HashMap::new()),
+            signatures: RwLock::new(HashMap::new()),
+            nontrans_couplets: RwLock::new(HashMap::new()),
+            trans_receipts: RwLock::new(HashMap::new()),
+        }
+    }
+
+    fn log_event_internal(&self, event: &SignedEventMessage) {
+        if let Ok(digest) = event.event_message.digest() {
+            let timestamped = Timestamped::new(event.clone());
+            self.events.write().unwrap().insert(digest.clone(), timestamped);
+            self.signatures
+                .write()
+                .unwrap()
+                .insert(digest, event.signatures.clone());
+        }
+    }
+
+    fn log_receipt_internal(&self, receipt: &SignedNontransferableReceipt) {
+        let digest = receipt.body.receipted_event_digest.clone();
+        self.nontrans_couplets
+            .write()
+            .unwrap()
+            .entry(digest)
+            .or_default()
+            .extend(receipt.signatures.clone());
+    }
+}
+
+impl LogDatabase<'static> for MemoryLogDatabase {
+    type DatabaseType = ();
+    type Error = Error;
+    type TransactionType = ();
+
+    fn new(_db: Arc<Self::DatabaseType>) -> Result<Self, Self::Error> {
+        Ok(Self::new())
+    }
+
+    fn log_event(
+        &self,
+        _txn: &Self::TransactionType,
+        signed_event: &SignedEventMessage,
+    ) -> Result<(), Self::Error> {
+        self.log_event_internal(signed_event);
+        Ok(())
+    }
+
+    fn log_event_with_new_transaction(
+        &self,
+        signed_event: &SignedEventMessage,
+    ) -> Result<(), Self::Error> {
+        self.log_event_internal(signed_event);
+        Ok(())
+    }
+
+    fn log_receipt(
+        &self,
+        _txn: &Self::TransactionType,
+        signed_receipt: &SignedNontransferableReceipt,
+    ) -> Result<(), Self::Error> {
+        self.log_receipt_internal(signed_receipt);
+        Ok(())
+    }
+
+    fn log_receipt_with_new_transaction(
+        &self,
+        signed_receipt: &SignedNontransferableReceipt,
+    ) -> Result<(), Self::Error> {
+        self.log_receipt_internal(signed_receipt);
+        Ok(())
+    }
+
+    fn get_signed_event(
+        &self,
+        said: &SelfAddressingIdentifier,
+    ) -> Result<Option<TimestampedSignedEventMessage>, Self::Error> {
+        Ok(self.events.read().unwrap().get(said).cloned())
+    }
+
+    fn get_event(
+        &self,
+        said: &SelfAddressingIdentifier,
+    ) -> Result<Option<KeriEvent<KeyEvent>>, Self::Error> {
+        Ok(self
+            .events
+            .read()
+            .unwrap()
+            .get(said)
+            .map(|t| t.signed_event_message.event_message.clone()))
+    }
+
+    fn get_signatures(
+        &self,
+        said: &SelfAddressingIdentifier,
+    ) -> Result<Option<impl Iterator<Item = IndexedSignature>>, Self::Error> {
+        Ok(self
+            .signatures
+            .read()
+            .unwrap()
+            .get(said)
+            .cloned()
+            .map(|v| v.into_iter()))
+    }
+
+    fn get_nontrans_couplets(
+        &self,
+        said: &SelfAddressingIdentifier,
+    ) -> Result<Option<impl Iterator<Item = Nontransferable>>, Self::Error> {
+        Ok(self
+            .nontrans_couplets
+            .read()
+            .unwrap()
+            .get(said)
+            .cloned()
+            .map(|v| v.into_iter()))
+    }
+
+    fn get_trans_receipts(
+        &self,
+        said: &SelfAddressingIdentifier,
+    ) -> Result<impl DoubleEndedIterator<Item = Transferable>, Self::Error> {
+        Ok(self
+            .trans_receipts
+            .read()
+            .unwrap()
+            .get(said)
+            .cloned()
+            .unwrap_or_default()
+            .into_iter())
+    }
+
+    fn remove_nontrans_receipt(
+        &self,
+        _txn_mode: &Self::TransactionType,
+        said: &SelfAddressingIdentifier,
+        nontrans: impl IntoIterator<Item = Nontransferable>,
+    ) -> Result<(), Self::Error> {
+        let to_remove: Vec<_> = nontrans.into_iter().collect();
+        if let Some(existing) = self.nontrans_couplets.write().unwrap().get_mut(said) {
+            existing.retain(|n| !to_remove.contains(n));
+        }
+        Ok(())
+    }
+
+    fn remove_nontrans_receipt_with_new_transaction(
+        &self,
+        said: &SelfAddressingIdentifier,
+        nontrans: impl IntoIterator<Item = Nontransferable>,
+    ) -> Result<(), Self::Error> {
+        self.remove_nontrans_receipt(&(), said, nontrans)
+    }
+}
+
+/// In-memory sequenced event database for escrow storage.
+pub struct MemorySequencedEventDb {
+    data: RwLock<HashMap<(IdentifierPrefix, u64), Vec<SelfAddressingIdentifier>>>,
+}
+
+impl MemorySequencedEventDb {
+    pub fn new() -> Self {
+        Self {
+            data: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl SequencedEventDatabase for MemorySequencedEventDb {
+    type DatabaseType = ();
+    type Error = Error;
+    type DigestIter = Box<dyn Iterator<Item = SelfAddressingIdentifier>>;
+
+    fn new(_db: Arc<Self::DatabaseType>, _table_name: &'static str) -> Result<Self, Self::Error> {
+        Ok(Self::new())
+    }
+
+    fn insert(
+        &self,
+        identifier: &IdentifierPrefix,
+        sn: u64,
+        digest: &SelfAddressingIdentifier,
+    ) -> Result<(), Self::Error> {
+        self.data
+            .write()
+            .unwrap()
+            .entry((identifier.clone(), sn))
+            .or_default()
+            .push(digest.clone());
+        Ok(())
+    }
+
+    fn get(
+        &self,
+        identifier: &IdentifierPrefix,
+        sn: u64,
+    ) -> Result<Self::DigestIter, Self::Error> {
+        let data = self.data.read().unwrap();
+        let items = data
+            .get(&(identifier.clone(), sn))
+            .cloned()
+            .unwrap_or_default();
+        Ok(Box::new(items.into_iter()))
+    }
+
+    fn get_greater_than(
+        &self,
+        identifier: &IdentifierPrefix,
+        sn: u64,
+    ) -> Result<Self::DigestIter, Self::Error> {
+        let data = self.data.read().unwrap();
+        let items: Vec<_> = data
+            .iter()
+            .filter(|((id, s), _)| id == identifier && *s >= sn)
+            .flat_map(|(_, v)| v.clone())
+            .collect();
+        Ok(Box::new(items.into_iter()))
+    }
+
+    fn remove(
+        &self,
+        identifier: &IdentifierPrefix,
+        sn: u64,
+        said: &SelfAddressingIdentifier,
+    ) -> Result<(), Self::Error> {
+        if let Some(v) = self.data.write().unwrap().get_mut(&(identifier.clone(), sn)) {
+            v.retain(|d| d != said);
+        }
+        Ok(())
+    }
+}
+
+/// In-memory escrow database.
+pub struct MemoryEscrowDb {
+    sequenced: Arc<MemorySequencedEventDb>,
+    log: Arc<MemoryLogDatabase>,
+}
+
+impl EscrowDatabase for MemoryEscrowDb {
+    type EscrowDatabaseType = ();
+    type LogDatabaseType = MemoryLogDatabase;
+    type Error = Error;
+    type EventIter = std::vec::IntoIter<SignedEventMessage>;
+
+    fn new(
+        _escrow: Arc<
+            dyn SequencedEventDatabase<
+                DatabaseType = Self::EscrowDatabaseType,
+                Error = Self::Error,
+                DigestIter = Box<dyn Iterator<Item = SelfAddressingIdentifier>>,
+            >,
+        >,
+        log: Arc<Self::LogDatabaseType>,
+    ) -> Self {
+        // We won't use this constructor in practice; use from_parts instead
+        Self {
+            sequenced: Arc::new(MemorySequencedEventDb::new()),
+            log,
+        }
+    }
+
+    fn save_digest(
+        &self,
+        id: &IdentifierPrefix,
+        sn: u64,
+        event_digest: &SelfAddressingIdentifier,
+    ) -> Result<(), Self::Error> {
+        self.sequenced.insert(id, sn, event_digest)
+    }
+
+    fn insert(&self, event: &SignedEventMessage) -> Result<(), Self::Error> {
+        let digest = event.event_message.digest()?;
+        let sn = event.event_message.data.get_sn();
+        let id = event.event_message.data.get_prefix();
+        self.sequenced.insert(&id, sn, &digest)?;
+        self.log.log_event_internal(event);
+        Ok(())
+    }
+
+    fn insert_key_value(
+        &self,
+        id: &IdentifierPrefix,
+        sn: u64,
+        event: &SignedEventMessage,
+    ) -> Result<(), Self::Error> {
+        let digest = event.event_message.digest()?;
+        self.sequenced.insert(id, sn, &digest)?;
+        self.log.log_event_internal(event);
+        Ok(())
+    }
+
+    fn get(
+        &self,
+        identifier: &IdentifierPrefix,
+        sn: u64,
+    ) -> Result<Self::EventIter, Self::Error> {
+        let digests = self.sequenced.get(identifier, sn)?;
+        let events: Vec<_> = digests
+            .filter_map(|d| {
+                self.log
+                    .get_signed_event(&d)
+                    .ok()
+                    .flatten()
+                    .map(|t| t.signed_event_message)
+            })
+            .collect();
+        Ok(events.into_iter())
+    }
+
+    fn get_from_sn(
+        &self,
+        identifier: &IdentifierPrefix,
+        sn: u64,
+    ) -> Result<Self::EventIter, Self::Error> {
+        let digests = self.sequenced.get_greater_than(identifier, sn)?;
+        let events: Vec<_> = digests
+            .filter_map(|d| {
+                self.log
+                    .get_signed_event(&d)
+                    .ok()
+                    .flatten()
+                    .map(|t| t.signed_event_message)
+            })
+            .collect();
+        Ok(events.into_iter())
+    }
+
+    fn remove(&self, event: &KeriEvent<KeyEvent>) {
+        if let Ok(digest) = event.digest() {
+            let sn = event.data.get_sn();
+            let id = event.data.get_prefix();
+            let _ = self.sequenced.remove(&id, sn, &digest);
+        }
+    }
+
+    fn contains(
+        &self,
+        id: &IdentifierPrefix,
+        sn: u64,
+        digest: &SelfAddressingIdentifier,
+    ) -> Result<bool, Self::Error> {
+        let digests = self.sequenced.get(id, sn)?;
+        Ok(digests.collect::<Vec<_>>().contains(digest))
+    }
+}
+
+impl EscrowCreator for MemoryDatabase {
+    type EscrowDatabaseType = MemoryEscrowDb;
+
+    fn create_escrow_db(&self, table_name: &'static str) -> Self::EscrowDatabaseType {
+        let seq = Arc::new(MemorySequencedEventDb::new());
+        self.escrow_db
+            .write()
+            .unwrap()
+            .insert(table_name, seq.clone());
+        MemoryEscrowDb {
+            sequenced: seq,
+            log: self.log_db.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{convert::TryFrom, sync::Arc};
+
+    use cesrox::parse;
+
+    use super::MemoryDatabase;
+    use crate::{
+        error::Error,
+        event_message::signed_event_message::{Message, Notice},
+        processor::{
+            basic_processor::BasicProcessor, event_storage::EventStorage, Processor,
+        },
+    };
+
+    #[test]
+    fn test_memory_db_process_icp() -> Result<(), Error> {
+        let db = Arc::new(MemoryDatabase::new());
+        let processor = BasicProcessor::new(db.clone(), None);
+        let storage = EventStorage::new(db.clone());
+
+        // Inception event from keripy test_multisig_digprefix
+        let icp_raw = br#"{"v":"KERI10JSON0001e7_","t":"icp","d":"EBfxc4RiVY6saIFmUfEtETs1FcqmktZW88UkbnOg0Qen","i":"EBfxc4RiVY6saIFmUfEtETs1FcqmktZW88UkbnOg0Qen","s":"0","kt":"2","k":["DErocgXD2RGSyvn3MObcx59jeOsEQhv2TqHirVkzrp0Q","DFXLiTjiRdSBPLL6hLa0rskIxk3dh4XwJLfctkJFLRSS","DE9YgIQVgpLwocTVrG8tidKScsQSMWwLWywNC48fhq4f"],"nt":"2","n":["EDJk5EEpC4-tQ7YDwBiKbpaZahh1QCyQOnZRF7p2i8k8","EAXfDjKvUFRj-IEB_o4y-Y_qeJAjYfZtOMD9e7vHNFss","EN8l6yJC2PxribTN0xfri6bLz34Qvj-x3cNwcV3DvT2m"],"bt":"0","b":[],"c":[],"a":[]}-AADAAD4SyJSYlsQG22MGXzRGz2PTMqpkgOyUfq7cS99sC2BCWwdVmEMKiTEeWe5kv-l_d9auxdadQuArLtAGEArW8wEABD0z_vQmFImZXfdR-0lclcpZFfkJJJNXDcUNrf7a-mGsxNLprJo-LROwDkH5m7tVrb-a1jcor2dHD9Jez-r4bQIACBFeU05ywfZycLdR0FxCvAR9BfV9im8tWe1DglezqJLf-vHRQSChY1KafbYNc96hYYpbuN90WzuCRMgV8KgRsEC"#;
+        let parsed = parse(icp_raw).unwrap().1;
+        let deserialized_icp = Message::try_from(parsed).unwrap();
+
+        let id = match &deserialized_icp {
+            Message::Notice(Notice::Event(e)) => e.event_message.data.get_prefix(),
+            _ => panic!("unexpected message type"),
+        };
+
+        // Process inception event
+        processor.process(&deserialized_icp)?;
+
+        // Verify state was created
+        let state = storage.get_state(&id);
+        assert!(state.is_some());
+        let state = state.unwrap();
+        assert_eq!(state.sn, 0);
+        assert_eq!(state.current.public_keys.len(), 3);
+
+        // Verify KEL has the event
+        let kel = storage.get_kel_messages(&id)?;
+        assert!(kel.is_some());
+        assert_eq!(kel.unwrap().len(), 1);
+
+        Ok(())
+    }
+}

--- a/keriox_core/src/database/mod.rs
+++ b/keriox_core/src/database/mod.rs
@@ -19,7 +19,10 @@ use crate::{
 
 #[cfg(feature = "mailbox")]
 pub mod mailbox;
+pub mod memory;
+#[cfg(feature = "storage-redb")]
 pub mod redb;
+pub(crate) mod rkyv_adapter;
 pub mod timestamped;
 
 pub enum QueryParameters<'a> {

--- a/keriox_core/src/database/mod.rs
+++ b/keriox_core/src/database/mod.rs
@@ -20,6 +20,8 @@ use crate::{
 #[cfg(feature = "mailbox")]
 pub mod mailbox;
 pub mod memory;
+#[cfg(feature = "storage-postgres")]
+pub mod postgres;
 #[cfg(feature = "storage-redb")]
 pub mod redb;
 pub(crate) mod rkyv_adapter;

--- a/keriox_core/src/database/postgres/error.rs
+++ b/keriox_core/src/database/postgres/error.rs
@@ -1,0 +1,15 @@
+#[derive(Debug, thiserror::Error)]
+pub enum PostgresError {
+    #[error("Database error: {0}")]
+    Sqlx(#[from] sqlx::Error),
+    #[error("Migration error: {0}")]
+    Migration(#[from] sqlx::migrate::MigrateError),
+    #[error("Rkyv serialization error: {0}")]
+    Rkyv(#[from] rkyv::rancor::Error),
+    #[error("No event for digest {0} found")]
+    NotFound(said::SelfAddressingIdentifier),
+    #[error("No digest in provided event")]
+    MissingDigest,
+    #[error("Already saved: {0}")]
+    AlreadySaved(said::SelfAddressingIdentifier),
+}

--- a/keriox_core/src/database/postgres/error.rs
+++ b/keriox_core/src/database/postgres/error.rs
@@ -6,6 +6,10 @@ pub enum PostgresError {
     Migration(#[from] sqlx::migrate::MigrateError),
     #[error("Rkyv serialization error: {0}")]
     Rkyv(#[from] rkyv::rancor::Error),
+    #[error("CBOR error: {0}")]
+    Cbor(#[from] serde_cbor::Error),
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
     #[error("No event for digest {0} found")]
     NotFound(said::SelfAddressingIdentifier),
     #[error("No digest in provided event")]

--- a/keriox_core/src/database/postgres/escrow_database.rs
+++ b/keriox_core/src/database/postgres/escrow_database.rs
@@ -73,7 +73,6 @@ impl EscrowDatabase for PostgresSnKeyEscrow {
         self.escrow.insert(id, sn, event_digest)
     }
 
-    //TODO: do i need a transaction here
     fn insert(&self, event: &SignedEventMessage) -> Result<(), Self::Error> {
         self.log
             .log_event(&PostgresWriteTxnMode::CreateNew, event)?;
@@ -85,7 +84,6 @@ impl EscrowDatabase for PostgresSnKeyEscrow {
         Ok(())
     }
 
-    //TODO: do I need transaction here
     fn insert_key_value(
         &self,
         id: &IdentifierPrefix,

--- a/keriox_core/src/database/postgres/escrow_database.rs
+++ b/keriox_core/src/database/postgres/escrow_database.rs
@@ -1,0 +1,288 @@
+use std::sync::Arc;
+
+use said::SelfAddressingIdentifier;
+use sqlx::{PgPool, Row};
+
+use crate::{
+    database::{
+        postgres::{
+            error::PostgresError, loging::PostgresWriteTxnMode, PostgresDatabase,
+            PostgresLogDatabase,
+        },
+        rkyv_adapter::{self, serialize_said},
+        EscrowCreator, EscrowDatabase, LogDatabase as _, SequencedEventDatabase,
+    },
+    event::KeyEvent,
+    event_message::{msg::KeriEvent, signed_event_message::SignedEventMessage},
+    prefix::IdentifierPrefix,
+};
+
+impl EscrowCreator for PostgresDatabase {
+    type EscrowDatabaseType = PostgresSnKeyEscrow;
+
+    fn create_escrow_db(&self, table_name: &'static str) -> Self::EscrowDatabaseType {
+        PostgresSnKeyEscrow::new(
+            Arc::new(PostgresSnKeyDatabase::new(self.pool.clone(), table_name)),
+            self.log_db.clone(),
+        )
+    }
+}
+
+pub struct PostgresSnKeyEscrow {
+    escrow: Arc<
+        dyn SequencedEventDatabase<
+            DatabaseType = PgPool,
+            Error = PostgresError,
+            DigestIter = Box<dyn Iterator<Item = SelfAddressingIdentifier>>,
+        >,
+    >,
+    log: Arc<PostgresLogDatabase>,
+}
+
+impl EscrowDatabase for PostgresSnKeyEscrow {
+    type EscrowDatabaseType = PgPool;
+
+    type LogDatabaseType = PostgresLogDatabase;
+
+    type Error = PostgresError;
+
+    type EventIter = Box<dyn Iterator<Item = SignedEventMessage> + Send>;
+
+    fn new(
+        escrow: Arc<
+            dyn SequencedEventDatabase<
+                DatabaseType = Self::EscrowDatabaseType,
+                Error = Self::Error,
+                DigestIter = Box<dyn Iterator<Item = said::SelfAddressingIdentifier>>,
+            >,
+        >,
+        log: Arc<Self::LogDatabaseType>,
+    ) -> Self
+    where
+        Self: Sized,
+    {
+        Self { escrow, log }
+    }
+
+    fn save_digest(
+        &self,
+        id: &IdentifierPrefix,
+        sn: u64,
+        event_digest: &said::SelfAddressingIdentifier,
+    ) -> Result<(), Self::Error> {
+        self.escrow.insert(id, sn, event_digest)
+    }
+
+    //TODO: do i need a transaction here
+    fn insert(&self, event: &SignedEventMessage) -> Result<(), Self::Error> {
+        self.log
+            .log_event(&PostgresWriteTxnMode::CreateNew, event)?;
+        let said = event.event_message.digest().unwrap();
+        let id = event.event_message.data.get_prefix();
+        let sn = event.event_message.data.sn;
+        self.escrow.insert(&id, sn, &said)?;
+
+        Ok(())
+    }
+
+    //TODO: do I need transaction here
+    fn insert_key_value(
+        &self,
+        id: &IdentifierPrefix,
+        sn: u64,
+        event: &SignedEventMessage,
+    ) -> Result<(), Self::Error> {
+        self.log
+            .log_event(&PostgresWriteTxnMode::CreateNew, event)?;
+        let said = event.event_message.digest().unwrap();
+
+        self.escrow.insert(id, sn, &said)?;
+
+        Ok(())
+    }
+
+    fn get(&self, identifier: &IdentifierPrefix, sn: u64) -> Result<Self::EventIter, Self::Error> {
+        let saids = self.escrow.get(identifier, sn)?;
+        let saids_vec: Vec<_> = saids.collect();
+
+        let log = Arc::clone(&self.log);
+
+        let events = saids_vec.into_iter().filter_map(move |said| {
+            log.get_signed_event(&said)
+                .ok()
+                .flatten()
+                .map(|el| el.signed_event_message)
+        });
+
+        Ok(Box::new(events))
+    }
+
+    fn get_from_sn(
+        &self,
+        identifier: &IdentifierPrefix,
+        sn: u64,
+    ) -> Result<Self::EventIter, Self::Error> {
+        let saids: Vec<_> = self.escrow.get_greater_than(identifier, sn)?.collect();
+        let log = Arc::clone(&self.log);
+
+        let events = saids.into_iter().filter_map(move |said| {
+            log.get_signed_event(&said)
+                .ok()
+                .flatten()
+                .map(|el| el.signed_event_message)
+        });
+
+        Ok(Box::new(events))
+    }
+
+    fn remove(&self, event: &KeriEvent<KeyEvent>) {
+        let said = event.digest().unwrap();
+        let id = event.data.get_prefix();
+        let sn = event.data.sn;
+        self.escrow.remove(&id, sn, &said).unwrap();
+    }
+
+    fn contains(
+        &self,
+        id: &IdentifierPrefix,
+        sn: u64,
+        digest: &said::SelfAddressingIdentifier,
+    ) -> Result<bool, PostgresError> {
+        Ok(self
+            .escrow
+            .get(id, sn)?
+            .find(|said| said == digest)
+            .is_some())
+    }
+}
+
+pub struct PostgresSnKeyDatabase {
+    pool: PgPool,
+    escrow_type: &'static str,
+}
+
+impl PostgresSnKeyDatabase {
+    pub fn new(pool: PgPool, escrow_type: &'static str) -> Self {
+        Self { pool, escrow_type }
+    }
+}
+
+impl SequencedEventDatabase for PostgresSnKeyDatabase {
+    type DatabaseType = PgPool;
+
+    type Error = PostgresError;
+
+    type DigestIter = Box<dyn Iterator<Item = SelfAddressingIdentifier>>;
+
+    fn new(db: Arc<Self::DatabaseType>, table_name: &'static str) -> Result<Self, Self::Error>
+    where
+        Self: Sized,
+    {
+        Ok(Self {
+            pool: (*db).clone(),
+            escrow_type: table_name,
+        })
+    }
+
+    fn insert(
+        &self,
+        identifier: &IdentifierPrefix,
+        sn: u64,
+        digest: &said::SelfAddressingIdentifier,
+    ) -> Result<(), PostgresError> {
+        let id_str = identifier.to_string();
+        let digest_bytes = rkyv_adapter::serialize_said(digest)?;
+        async_std::task::block_on(
+            sqlx::query(
+                "INSERT INTO escrow_events (escrow_type, identifier, sn, digest) \
+                    VALUES ($1, $2, $3, $4) \
+                    ON CONFLICT DO NOTHING",
+            )
+            .bind(self.escrow_type)
+            .bind(&id_str)
+            .bind(sn as i64)
+            .bind(digest_bytes.as_ref())
+            .execute(&self.pool),
+        )?;
+        Ok(())
+    }
+
+    fn get(
+        &self,
+        identifier: &IdentifierPrefix,
+        sn: u64,
+    ) -> Result<Self::DigestIter, PostgresError> {
+        let id_str = identifier.to_string();
+        let rows = async_std::task::block_on(
+            sqlx::query(
+                "SELECT digest FROM escrow_events \
+                    WHERE escrow_type = $1 AND identifier = $2 AND sn = $3",
+            )
+            .bind(self.escrow_type)
+            .bind(&id_str)
+            .bind(sn as i64)
+            .fetch_all(&self.pool),
+        )?;
+
+        let saids: Vec<SelfAddressingIdentifier> = rows
+            .into_iter()
+            .filter_map(|row| {
+                let bytes: Vec<u8> = row.get("digest");
+                rkyv_adapter::deserialize_said(&bytes).ok()
+            })
+            .collect();
+
+        Ok(Box::new(saids.into_iter()))
+    }
+
+    fn get_greater_than(
+        &self,
+        identifier: &IdentifierPrefix,
+        sn: u64,
+    ) -> Result<Self::DigestIter, PostgresError> {
+        let id_str = identifier.to_string();
+        let rows = async_std::task::block_on(
+            sqlx::query(
+                "SELECT digest FROM escrow_events \
+                    WHERE escrow_type = $1 AND identifier = $2 AND sn > $3 \
+                    ORDER BY sn ASC",
+            )
+            .bind(self.escrow_type)
+            .bind(&id_str)
+            .bind(sn as i64)
+            .fetch_all(&self.pool),
+        )?;
+
+        let saids: Vec<SelfAddressingIdentifier> = rows
+            .into_iter()
+            .filter_map(|row| {
+                let bytes: Vec<u8> = row.get("digest");
+                rkyv_adapter::deserialize_said(&bytes).ok()
+            })
+            .collect();
+
+        Ok(Box::new(saids.into_iter()))
+    }
+
+    fn remove(
+        &self,
+        identifier: &IdentifierPrefix,
+        sn: u64,
+        said: &said::SelfAddressingIdentifier,
+    ) -> Result<(), PostgresError> {
+        let id_str = identifier.to_string();
+        let digest_bytes = serialize_said(said)?;
+        async_std::task::block_on(
+            sqlx::query(
+                "DELETE FROM escrow_events \
+                    WHERE escrow_type = $1 AND identifier = $2 AND sn = $3 AND digest = $4",
+            )
+            .bind(self.escrow_type)
+            .bind(&id_str)
+            .bind(sn as i64)
+            .bind(digest_bytes.as_ref())
+            .execute(&self.pool),
+        )?;
+        Ok(())
+    }
+}

--- a/keriox_core/src/database/postgres/ksn_log.rs
+++ b/keriox_core/src/database/postgres/ksn_log.rs
@@ -1,0 +1,178 @@
+use std::sync::Arc;
+
+use said::SelfAddressingIdentifier;
+use sqlx::{PgPool, Row};
+
+use crate::{
+    database::{
+        postgres::{error::PostgresError, loging::PostgresWriteTxnMode},
+        rkyv_adapter,
+    },
+    prefix::IdentifierPrefix,
+    query::reply_event::{ReplyRoute, SignedReply},
+};
+
+pub struct KsnLogDatabase {
+    pool: PgPool,
+}
+
+pub struct AcceptedKsn {
+    ksn_log: Arc<KsnLogDatabase>,
+    pool: PgPool,
+}
+
+impl AcceptedKsn {
+    pub fn new(pool: PgPool) -> Self {
+        let ksn_log = Arc::new(KsnLogDatabase::new(pool.clone()));
+        Self { ksn_log, pool }
+    }
+
+    pub fn insert(&self, reply: SignedReply) -> Result<(), PostgresError> {
+        let (from_who, about_who) = match reply.reply.get_route() {
+            ReplyRoute::Ksn(id, ksn) => (id, ksn.state.prefix),
+            _ => panic!("Wrong event type"),
+        };
+
+        let digest = reply
+            .reply
+            .digest()
+            .map_err(|_| PostgresError::MissingDigest)?;
+        let serialized_digest = rkyv_adapter::serialize_said(&digest)?;
+
+        async_std::task::block_on(async {
+            let mut tx = self.pool.begin().await?;
+
+            // Store the KSN event itself
+            let value = serde_cbor::to_vec(&reply).unwrap();
+            sqlx::query(
+                "INSERT INTO ksns (digest, ksn_data) VALUES ($1, $2) \
+                   ON CONFLICT (digest) DO NOTHING",
+            )
+            .bind(serialized_digest.as_ref())
+            .bind(value.as_slice())
+            .execute(&mut *tx)
+            .await?;
+
+            // Update the accepted index
+            sqlx::query(
+                "INSERT INTO accepted_ksns (about_who, from_who, digest) VALUES ($1, $2, $3) \
+                   ON CONFLICT (about_who, from_who) DO UPDATE SET digest = $3",
+            )
+            .bind(about_who.to_string())
+            .bind(from_who.to_string())
+            .bind(serialized_digest.as_ref())
+            .execute(&mut *tx)
+            .await?;
+
+            tx.commit().await?;
+            Ok(())
+        })
+    }
+
+    pub fn get_all(&self, id: &IdentifierPrefix) -> Result<Vec<SignedReply>, PostgresError> {
+        async_std::task::block_on(async {
+            let rows = sqlx::query("SELECT digest FROM accepted_ksns WHERE about_who = $1")
+                .bind(id.to_string())
+                .fetch_all(&self.pool)
+                .await?;
+
+            let mut replies = Vec::new();
+            for row in rows {
+                let digest_bytes: Vec<u8> = row.get("digest");
+                let said = rkyv_adapter::deserialize_said(&digest_bytes)?;
+                if let Some(reply) = self.ksn_log.get_signed_reply(&said)? {
+                    replies.push(reply);
+                }
+            }
+            Ok(replies)
+        })
+    }
+
+    pub fn get(
+        &self,
+        id: &IdentifierPrefix,
+        from_who: &IdentifierPrefix,
+    ) -> Result<Option<SignedReply>, PostgresError> {
+        async_std::task::block_on(async {
+            let row = sqlx::query(
+                "SELECT digest FROM accepted_ksns WHERE about_who = $1 AND from_who = $2",
+            )
+            .bind(id.to_string())
+            .bind(from_who.to_string())
+            .fetch_optional(&self.pool)
+            .await?;
+
+            match row {
+                Some(row) => {
+                    let digest_bytes: Vec<u8> = row.get("digest");
+                    let said = rkyv_adapter::deserialize_said(&digest_bytes)?;
+                    self.ksn_log.get_signed_reply(&said)
+                }
+                None => Ok(None),
+            }
+        })
+    }
+}
+
+impl KsnLogDatabase {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    fn insert_ksn(
+        &self,
+        _txn_mode: &PostgresWriteTxnMode,
+        event: &SignedReply,
+    ) -> Result<(), PostgresError> {
+        let digest = event
+            .reply
+            .digest()
+            .map_err(|_| PostgresError::MissingDigest)?;
+        let serialized_digest = rkyv_adapter::serialize_said(&digest)?;
+        let value = serde_cbor::to_vec(event).unwrap();
+
+        async_std::task::block_on(async {
+            sqlx::query(
+                "INSERT INTO ksns (digest, ksn_data) VALUES ($1, $2) \
+                      ON CONFLICT (digest) DO NOTHING",
+            )
+            .bind(serialized_digest.as_ref())
+            .bind(value.as_slice())
+            .execute(&self.pool)
+            .await?;
+            Ok(())
+        })
+    }
+
+    pub fn log_reply(
+        &self,
+        txn_mode: &PostgresWriteTxnMode,
+        signed_event: &SignedReply,
+    ) -> Result<(), PostgresError> {
+        self.insert_ksn(txn_mode, signed_event)?;
+        Ok(())
+    }
+
+    pub fn get_signed_reply(
+        &self,
+        said: &SelfAddressingIdentifier,
+    ) -> Result<Option<SignedReply>, PostgresError> {
+        let key = rkyv_adapter::serialize_said(said)?;
+
+        async_std::task::block_on(async {
+            let row = sqlx::query("SELECT ksn_data FROM ksns WHERE digest = $1")
+                .bind(key.as_ref())
+                .fetch_optional(&self.pool)
+                .await?;
+
+            match row {
+                Some(row) => {
+                    let bytes: Vec<u8> = row.get("ksn_data");
+                    let reply: SignedReply = serde_cbor::from_slice(&bytes).unwrap();
+                    Ok(Some(reply))
+                }
+                None => Ok(None),
+            }
+        })
+    }
+}

--- a/keriox_core/src/database/postgres/ksn_log.rs
+++ b/keriox_core/src/database/postgres/ksn_log.rs
@@ -5,7 +5,7 @@ use sqlx::{PgPool, Row};
 
 use crate::{
     database::{
-        postgres::{error::PostgresError, loging::PostgresWriteTxnMode},
+        postgres::error::PostgresError,
         rkyv_adapter,
     },
     prefix::IdentifierPrefix,
@@ -117,40 +117,6 @@ impl AcceptedKsn {
 impl KsnLogDatabase {
     pub fn new(pool: PgPool) -> Self {
         Self { pool }
-    }
-
-    fn insert_ksn(
-        &self,
-        _txn_mode: &PostgresWriteTxnMode,
-        event: &SignedReply,
-    ) -> Result<(), PostgresError> {
-        let digest = event
-            .reply
-            .digest()
-            .map_err(|_| PostgresError::MissingDigest)?;
-        let serialized_digest = rkyv_adapter::serialize_said(&digest)?;
-        let value = serde_cbor::to_vec(event).unwrap();
-
-        async_std::task::block_on(async {
-            sqlx::query(
-                "INSERT INTO ksns (digest, ksn_data) VALUES ($1, $2) \
-                      ON CONFLICT (digest) DO NOTHING",
-            )
-            .bind(serialized_digest.as_ref())
-            .bind(value.as_slice())
-            .execute(&self.pool)
-            .await?;
-            Ok(())
-        })
-    }
-
-    pub fn log_reply(
-        &self,
-        txn_mode: &PostgresWriteTxnMode,
-        signed_event: &SignedReply,
-    ) -> Result<(), PostgresError> {
-        self.insert_ksn(txn_mode, signed_event)?;
-        Ok(())
     }
 
     pub fn get_signed_reply(

--- a/keriox_core/src/database/postgres/loging.rs
+++ b/keriox_core/src/database/postgres/loging.rs
@@ -1,8 +1,6 @@
 use crate::{
     database::{
-        postgres::error::PostgresError,
-        rkyv_adapter,
-        timestamped::TimestampedSignedEventMessage,
+        postgres::error::PostgresError, rkyv_adapter, timestamped::TimestampedSignedEventMessage,
         LogDatabase as LogDatabaseTrait,
     },
     event::KeyEvent,
@@ -94,8 +92,6 @@ impl PostgresLogDatabase {
     /// which prevents passing a `&mut sqlx::Transaction` through the trait's `log_event`.
     /// This async method accepts an existing transaction directly so callers like
     /// `add_kel_finalized_event` can log events within the same transaction.
-    /// TODO: Consider changing the trait to take `&mut Self::TransactionType` so this
-    /// can be unified with `log_event`.
     pub async fn log_event_with_tx(
         &self,
         tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
@@ -273,7 +269,6 @@ impl<'db> LogDatabaseTrait<'db> for PostgresLogDatabase {
         })
     }
 
-    //TODO: add transaction
     fn log_event(
         &self,
         txn: &Self::TransactionType,

--- a/keriox_core/src/database/postgres/loging.rs
+++ b/keriox_core/src/database/postgres/loging.rs
@@ -271,7 +271,7 @@ impl<'db> LogDatabaseTrait<'db> for PostgresLogDatabase {
 
     fn log_event(
         &self,
-        txn: &Self::TransactionType,
+        _txn: &Self::TransactionType,
         signed_event: &SignedEventMessage,
     ) -> Result<(), Self::Error> {
         let digest = signed_event
@@ -345,7 +345,7 @@ impl<'db> LogDatabaseTrait<'db> for PostgresLogDatabase {
 
     fn log_receipt(
         &self,
-        txn: &Self::TransactionType,
+        _txn: &Self::TransactionType,
         signed_receipt: &crate::event_message::signed_event_message::SignedNontransferableReceipt,
     ) -> Result<(), Self::Error> {
         let digest = &signed_receipt.body.receipted_event_digest;
@@ -467,7 +467,7 @@ impl<'db> LogDatabaseTrait<'db> for PostgresLogDatabase {
 
     fn remove_nontrans_receipt(
         &self,
-        txn_mode: &Self::TransactionType,
+        _txn_mode: &Self::TransactionType,
         said: &said::SelfAddressingIdentifier,
         nontrans: impl IntoIterator<Item = Nontransferable>,
     ) -> Result<(), Self::Error> {

--- a/keriox_core/src/database/postgres/loging.rs
+++ b/keriox_core/src/database/postgres/loging.rs
@@ -208,11 +208,11 @@ impl PostgresLogDatabase {
 
     fn get_event_by_serialized_key(
         &self,
-        as_slice: &&[u8],
+        as_slice: &[u8],
     ) -> Result<Option<KeriEvent<KeyEvent>>, PostgresError> {
         async_std::task::block_on(async {
             let row = sqlx::query("SELECT event_data FROM events WHERE digest = $1")
-                .bind(*as_slice)
+                .bind(as_slice)
                 .fetch_optional(&self.pool)
                 .await?;
 
@@ -438,7 +438,7 @@ impl<'db> LogDatabaseTrait<'db> for PostgresLogDatabase {
         said: &said::SelfAddressingIdentifier,
     ) -> Result<Option<KeriEvent<KeyEvent>>, Self::Error> {
         let key = rkyv_adapter::serialize_said(said)?;
-        self.get_event_by_serialized_key(&key.as_slice())
+        self.get_event_by_serialized_key(key.as_slice())
     }
 
     fn get_signatures(

--- a/keriox_core/src/database/postgres/loging.rs
+++ b/keriox_core/src/database/postgres/loging.rs
@@ -1,0 +1,513 @@
+use crate::{
+    database::{
+        postgres::error::PostgresError,
+        rkyv_adapter,
+        timestamped::TimestampedSignedEventMessage,
+        LogDatabase as LogDatabaseTrait,
+    },
+    event::KeyEvent,
+    event_message::{
+        msg::KeriEvent,
+        signature::{Nontransferable, Transferable},
+        signed_event_message::SignedEventMessage,
+    },
+    prefix::IndexedSignature,
+};
+
+use rkyv::{
+    api::high::HighSerializer, rancor::Failure, ser::allocator::ArenaHandle, util::AlignedVec,
+};
+use said::SelfAddressingIdentifier;
+use sqlx::{PgPool, Row};
+
+pub struct PostgresLogDatabase {
+    pool: PgPool,
+}
+
+/// Transaction mode for PostgreSQL operations
+pub enum PostgresWriteTxnMode {
+    /// Create a new transaction
+    CreateNew,
+    /// Operations are executed without explicit transaction management
+    /// (caller is responsible for transaction handling)
+    NoTransaction,
+}
+
+impl PostgresLogDatabase {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+
+    fn insert_with_digest_key<
+        V: for<'a> rkyv::Serialize<HighSerializer<AlignedVec, ArenaHandle<'a>, rkyv::rancor::Error>>,
+    >(
+        &self,
+        table: &str,
+        value_column: &str,
+        said: &SelfAddressingIdentifier,
+        values: &[V],
+    ) -> Result<(), PostgresError> {
+        let serialized_said = rkyv_adapter::serialize_said(said)?;
+        let query = format!(
+            "INSERT INTO {table} (digest, {value_column}) VALUES ($1, $2) \
+             ON CONFLICT (digest, {value_column}) DO NOTHING"
+        );
+
+        async_std::task::block_on(async {
+            let mut tx = self.pool.begin().await?;
+
+            for value in values {
+                let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(value)?;
+                sqlx::query(&query)
+                    .bind(serialized_said.as_ref())
+                    .bind(bytes.as_ref())
+                    .execute(&mut *tx)
+                    .await?;
+            }
+
+            tx.commit().await?;
+            Ok(())
+        })
+    }
+
+    pub(super) fn insert_nontrans_receipt(
+        &self,
+        said: &SelfAddressingIdentifier,
+        nontrans: &[Nontransferable],
+    ) -> Result<(), PostgresError> {
+        self.insert_with_digest_key("nontrans_receipts", "receipt_data", said, nontrans)
+    }
+
+    pub(super) fn insert_trans_receipt(
+        &self,
+        said: &SelfAddressingIdentifier,
+        trans: &[Transferable],
+    ) -> Result<(), PostgresError> {
+        self.insert_with_digest_key("trans_receipts", "receipt_data", said, trans)
+    }
+
+    /// Workaround: The `LogDatabase` trait takes `&Self::TransactionType` (immutable),
+    /// which prevents passing a `&mut sqlx::Transaction` through the trait's `log_event`.
+    /// This async method accepts an existing transaction directly so callers like
+    /// `add_kel_finalized_event` can log events within the same transaction.
+    /// TODO: Consider changing the trait to take `&mut Self::TransactionType` so this
+    /// can be unified with `log_event`.
+    pub async fn log_event_with_tx(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        signed_event: &SignedEventMessage,
+    ) -> Result<(), PostgresError> {
+        let digest = signed_event
+            .event_message
+            .digest()
+            .map_err(|_| PostgresError::MissingDigest)?;
+        let serialized_digest = rkyv_adapter::serialize_said(&digest)?;
+
+        // 1. Store the event (digest -> event_data)
+        let event_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&signed_event.event_message)?;
+        sqlx::query(
+            "INSERT INTO events (digest, event_data) VALUES ($1, $2) \
+             ON CONFLICT (digest) DO NOTHING",
+        )
+        .bind(serialized_digest.as_ref())
+        .bind(event_bytes.as_ref())
+        .execute(&mut **tx)
+        .await?;
+
+        // 2. Store signatures (digest -> signature_data)
+        for sig in &signed_event.signatures {
+            let sig_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(sig)?;
+            sqlx::query(
+                "INSERT INTO signatures (digest, signature_data) VALUES ($1, $2) \
+                 ON CONFLICT (digest, signature_data) DO NOTHING",
+            )
+            .bind(serialized_digest.as_ref())
+            .bind(sig_bytes.as_ref())
+            .execute(&mut **tx)
+            .await?;
+        }
+
+        // 3. Store witness receipts (nontransferable)
+        if let Some(receipts) = &signed_event.witness_receipts {
+            for receipt in receipts {
+                let receipt_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(receipt)?;
+                sqlx::query(
+                    "INSERT INTO nontrans_receipts (digest, receipt_data) VALUES ($1, $2) \
+                     ON CONFLICT (digest, receipt_data) DO NOTHING",
+                )
+                .bind(serialized_digest.as_ref())
+                .bind(receipt_bytes.as_ref())
+                .execute(&mut **tx)
+                .await?;
+            }
+        }
+
+        // 4. Store delegator seal
+        if let Some(seal) = &signed_event.delegator_seal {
+            let seal_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(seal)?;
+            sqlx::query(
+                "INSERT INTO seals (digest, seal_data) VALUES ($1, $2) \
+                 ON CONFLICT (digest) DO NOTHING",
+            )
+            .bind(serialized_digest.as_ref())
+            .bind(seal_bytes.as_ref())
+            .execute(&mut **tx)
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    pub(super) fn get_nontrans_couplets_by_key(
+        &self,
+        key: &[u8],
+    ) -> Result<Option<impl Iterator<Item = Nontransferable>>, PostgresError> {
+        async_std::task::block_on(async {
+            let rows = sqlx::query("SELECT receipt_data FROM nontrans_receipts WHERE digest = $1")
+                .bind(key)
+                .fetch_all(&self.pool)
+                .await?;
+
+            let nontrans = rows
+                .into_iter()
+                .map(|row| {
+                    let bytes: Vec<u8> = row.get("receipt_data");
+                    rkyv_adapter::deserialize_nontransferable(&bytes).map_err(PostgresError::from)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            Ok(if nontrans.is_empty() {
+                None
+            } else {
+                Some(nontrans.into_iter())
+            })
+        })
+    }
+
+    fn get_trans_receipts_by_serialized_key(
+        &self,
+        key: &[u8],
+    ) -> Result<impl DoubleEndedIterator<Item = Transferable>, PostgresError> {
+        async_std::task::block_on(async {
+            let rows = sqlx::query("SELECT receipt_data FROM trans_receipts WHERE digest = $1")
+                .bind(key)
+                .fetch_all(&self.pool)
+                .await?;
+
+            let trans = rows
+                .into_iter()
+                .map(|row| {
+                    let bytes: Vec<u8> = row.get("receipt_data");
+                    rkyv_adapter::deserialize_transferable(&bytes).map_err(PostgresError::from)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            Ok(trans.into_iter())
+        })
+    }
+
+    fn get_event_by_serialized_key(
+        &self,
+        as_slice: &&[u8],
+    ) -> Result<Option<KeriEvent<KeyEvent>>, PostgresError> {
+        async_std::task::block_on(async {
+            let row = sqlx::query("SELECT event_data FROM events WHERE digest = $1")
+                .bind(*as_slice)
+                .fetch_optional(&self.pool)
+                .await?;
+
+            match row {
+                Some(row) => {
+                    let bytes: Vec<u8> = row.get("event_data");
+                    let event = rkyv::from_bytes::<_, Failure>(&bytes).unwrap();
+                    Ok(Some(event))
+                }
+                None => Ok(None),
+            }
+        })
+    }
+
+    fn get_signatures_by_serialized_key(
+        &self,
+        key: &[u8],
+    ) -> Result<Option<impl Iterator<Item = IndexedSignature>>, PostgresError> {
+        async_std::task::block_on(async {
+            let rows = sqlx::query("SELECT signature_data FROM signatures WHERE digest = $1")
+                .bind(key)
+                .fetch_all(&self.pool)
+                .await?;
+
+            let sigs = rows
+                .into_iter()
+                .map(|row| {
+                    let bytes: Vec<u8> = row.get("signature_data");
+                    rkyv_adapter::deserialize_indexed_signatures(&bytes)
+                        .map_err(PostgresError::from)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            Ok(if sigs.is_empty() {
+                None
+            } else {
+                Some(sigs.into_iter())
+            })
+        })
+    }
+}
+
+impl<'db> LogDatabaseTrait<'db> for PostgresLogDatabase {
+    type DatabaseType = PgPool;
+    type Error = PostgresError;
+    type TransactionType = PostgresWriteTxnMode;
+
+    fn new(db: std::sync::Arc<Self::DatabaseType>) -> Result<Self, PostgresError>
+    where
+        Self: Sized,
+    {
+        Ok(Self {
+            pool: (*db).clone(),
+        })
+    }
+
+    //TODO: add transaction
+    fn log_event(
+        &self,
+        txn: &Self::TransactionType,
+        signed_event: &SignedEventMessage,
+    ) -> Result<(), Self::Error> {
+        let digest = signed_event
+            .event_message
+            .digest()
+            .map_err(|_| PostgresError::MissingDigest)?;
+        let serialized_digest = rkyv_adapter::serialize_said(&digest)?;
+
+        // 1. Store the event (digest -> event_data)
+        let event_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&signed_event.event_message)?;
+        async_std::task::block_on(async {
+            sqlx::query(
+                "INSERT INTO events (digest, event_data) VALUES ($1, $2) \
+                     ON CONFLICT (digest) DO NOTHING",
+            )
+            .bind(serialized_digest.as_ref())
+            .bind(event_bytes.as_ref())
+            .execute(&self.pool)
+            .await?;
+
+            // 2. Store signatures (digest -> signature_data)
+            for sig in &signed_event.signatures {
+                let sig_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(sig)?;
+                sqlx::query(
+                    "INSERT INTO signatures (digest, signature_data) VALUES ($1, $2) \
+                         ON CONFLICT (digest, signature_data) DO NOTHING",
+                )
+                .bind(serialized_digest.as_ref())
+                .bind(sig_bytes.as_ref())
+                .execute(&self.pool)
+                .await?;
+            }
+
+            // 3. Store witness receipts (nontransferable)
+            if let Some(receipts) = &signed_event.witness_receipts {
+                for receipt in receipts {
+                    let receipt_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(receipt)?;
+                    sqlx::query(
+                        "INSERT INTO nontrans_receipts (digest, receipt_data) VALUES ($1, $2) \
+                             ON CONFLICT (digest, receipt_data) DO NOTHING",
+                    )
+                    .bind(serialized_digest.as_ref())
+                    .bind(receipt_bytes.as_ref())
+                    .execute(&self.pool)
+                    .await?;
+                }
+            }
+
+            // 4. Store delegator seal
+            if let Some(seal) = &signed_event.delegator_seal {
+                let seal_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(seal)?;
+                sqlx::query(
+                    "INSERT INTO seals (digest, seal_data) VALUES ($1, $2) \
+                         ON CONFLICT (digest) DO NOTHING",
+                )
+                .bind(serialized_digest.as_ref())
+                .bind(seal_bytes.as_ref())
+                .execute(&self.pool)
+                .await?;
+            }
+            Ok(())
+        })
+    }
+
+    fn log_event_with_new_transaction(
+        &self,
+        signed_event: &SignedEventMessage,
+    ) -> Result<(), Self::Error> {
+        self.log_event(&PostgresWriteTxnMode::CreateNew, signed_event)
+    }
+
+    fn log_receipt(
+        &self,
+        txn: &Self::TransactionType,
+        signed_receipt: &crate::event_message::signed_event_message::SignedNontransferableReceipt,
+    ) -> Result<(), Self::Error> {
+        let digest = &signed_receipt.body.receipted_event_digest;
+        self.insert_nontrans_receipt(digest, &signed_receipt.signatures)?;
+        Ok(())
+    }
+
+    fn log_receipt_with_new_transaction(
+        &self,
+        signed_receipt: &crate::event_message::signed_event_message::SignedNontransferableReceipt,
+    ) -> Result<(), Self::Error> {
+        self.log_receipt(&PostgresWriteTxnMode::CreateNew, signed_receipt)
+    }
+
+    fn get_signed_event(
+        &self,
+        said: &said::SelfAddressingIdentifier,
+    ) -> Result<Option<TimestampedSignedEventMessage>, Self::Error> {
+        let key = rkyv_adapter::serialize_said(said)?;
+
+        async_std::task::block_on(async {
+            // 1. Fetch event
+            let event_row = sqlx::query("SELECT event_data FROM events WHERE digest = $1")
+                .bind(key.as_ref())
+                .fetch_optional(&self.pool)
+                .await?;
+
+            let event_row = match event_row {
+                Some(row) => row,
+                None => return Ok(None),
+            };
+
+            let event_bytes: Vec<u8> = event_row.get("event_data");
+            let event: KeriEvent<KeyEvent> = rkyv::from_bytes::<_, Failure>(&event_bytes).unwrap();
+
+            // 2. Fetch signatures
+            let sig_rows = sqlx::query("SELECT signature_data FROM signatures WHERE digest = $1")
+                .bind(key.as_ref())
+                .fetch_all(&self.pool)
+                .await?;
+
+            let signatures: Vec<IndexedSignature> = sig_rows
+                .iter()
+                .filter_map(|row| {
+                    let bytes: Vec<u8> = row.get("signature_data");
+                    rkyv_adapter::deserialize_indexed_signatures(&bytes).ok()
+                })
+                .collect();
+
+            // 3. Fetch nontransferable receipts
+            let receipt_rows =
+                sqlx::query("SELECT receipt_data FROM nontrans_receipts WHERE digest = $1")
+                    .bind(key.as_ref())
+                    .fetch_all(&self.pool)
+                    .await?;
+
+            let receipts: Vec<Nontransferable> = receipt_rows
+                .iter()
+                .filter_map(|row| {
+                    let bytes: Vec<u8> = row.get("receipt_data");
+                    rkyv_adapter::deserialize_nontransferable(&bytes).ok()
+                })
+                .collect();
+
+            let witness_receipts = if receipts.is_empty() {
+                None
+            } else {
+                Some(receipts)
+            };
+
+            // 4. Fetch delegator seal
+            let seal_row = sqlx::query("SELECT seal_data FROM seals WHERE digest = $1")
+                .bind(key.as_ref())
+                .fetch_optional(&self.pool)
+                .await?;
+
+            let delegator_seal = seal_row.and_then(|row| {
+                let bytes: Vec<u8> = row.get("seal_data");
+                rkyv_adapter::deserialize_source_seal(&bytes).ok()
+            });
+
+            Ok(Some(TimestampedSignedEventMessage::new(
+                SignedEventMessage::new(&event, signatures, witness_receipts, delegator_seal),
+            )))
+        })
+    }
+
+    fn get_event(
+        &self,
+        said: &said::SelfAddressingIdentifier,
+    ) -> Result<Option<KeriEvent<KeyEvent>>, Self::Error> {
+        let key = rkyv_adapter::serialize_said(said)?;
+        self.get_event_by_serialized_key(&key.as_slice())
+    }
+
+    fn get_signatures(
+        &self,
+        said: &said::SelfAddressingIdentifier,
+    ) -> Result<Option<impl Iterator<Item = IndexedSignature>>, PostgresError> {
+        let key = rkyv_adapter::serialize_said(said)?;
+        self.get_signatures_by_serialized_key(key.as_ref())
+    }
+
+    fn get_nontrans_couplets(
+        &self,
+        said: &said::SelfAddressingIdentifier,
+    ) -> Result<Option<impl Iterator<Item = Nontransferable>>, PostgresError> {
+        let serialized_said = rkyv_adapter::serialize_said(said)?;
+        self.get_nontrans_couplets_by_key(serialized_said.as_ref())
+    }
+
+    fn get_trans_receipts(
+        &self,
+        said: &said::SelfAddressingIdentifier,
+    ) -> Result<impl DoubleEndedIterator<Item = Transferable>, PostgresError> {
+        let key = rkyv_adapter::serialize_said(said)?;
+        self.get_trans_receipts_by_serialized_key(key.as_slice())
+    }
+
+    fn remove_nontrans_receipt(
+        &self,
+        txn_mode: &Self::TransactionType,
+        said: &said::SelfAddressingIdentifier,
+        nontrans: impl IntoIterator<Item = Nontransferable>,
+    ) -> Result<(), Self::Error> {
+        async_std::task::block_on(async {
+            let serialized_said = rkyv_adapter::serialize_said(said)?;
+
+            let receipt_bytes: Result<Vec<Vec<u8>>, _> = nontrans
+                .into_iter()
+                .map(|receipt| {
+                    rkyv::to_bytes::<rkyv::rancor::Error>(&receipt)
+                        .map(|b| b.to_vec())
+                        .map_err(PostgresError::from)
+                })
+                .collect();
+            let receipt_bytes = receipt_bytes?;
+
+            if !receipt_bytes.is_empty() {
+                let receipt_refs: Vec<&[u8]> = receipt_bytes.iter().map(Vec::as_slice).collect();
+                sqlx::query(
+                    "DELETE FROM nontrans_receipts WHERE digest = $1 AND receipt_data = ANY($2)",
+                )
+                .bind(serialized_said.as_ref())
+                .bind(receipt_refs.as_slice())
+                .execute(&self.pool)
+                .await?;
+            }
+            Ok(())
+        })
+    }
+
+    fn remove_nontrans_receipt_with_new_transaction(
+        &self,
+        said: &said::SelfAddressingIdentifier,
+        nontrans: impl IntoIterator<Item = Nontransferable>,
+    ) -> Result<(), PostgresError> {
+        self.remove_nontrans_receipt(&PostgresWriteTxnMode::CreateNew, said, nontrans)
+    }
+}

--- a/keriox_core/src/database/postgres/migrations/001_initial_schema.sql
+++ b/keriox_core/src/database/postgres/migrations/001_initial_schema.sql
@@ -1,0 +1,152 @@
+-- ===========================================
+-- KEL Tables (EventDatabase)
+-- ===========================================
+
+-- Maps (identifier, sn) -> event_digest
+-- ReDB: KELS: TableDefinition<(&str, u64), &[u8]>
+CREATE TABLE kels (
+    identifier TEXT NOT NULL,
+    sn BIGINT NOT NULL,
+    digest BYTEA NOT NULL,
+    PRIMARY KEY (identifier, sn)  -- UNIQUE constraint prevents duplicate sn
+);
+CREATE INDEX idx_kels_identifier ON kels(identifier);
+
+-- Maps identifier -> serialized IdentifierState
+-- ReDB: KEY_STATES: TableDefinition<&str, &[u8]>
+CREATE TABLE key_states (
+    identifier TEXT PRIMARY KEY,
+    state_data BYTEA NOT NULL  -- rkyv serialized IdentifierState
+);
+
+-- Maps digest -> serialized event
+-- ReDB: EVENTS: TableDefinition<&[u8], &[u8]>
+CREATE TABLE events (
+    digest BYTEA PRIMARY KEY,
+    event_data BYTEA NOT NULL  -- rkyv serialized KeriEvent<KeyEvent>
+);
+
+-- Multimap: digest -> multiple signatures
+-- ReDB: SIGS: MultimapTableDefinition<&[u8], &[u8]>
+CREATE TABLE signatures (
+    digest BYTEA NOT NULL,
+    signature_data BYTEA NOT NULL,  -- rkyv serialized IndexedSignature
+    PRIMARY KEY (digest, signature_data)  -- Prevents duplicate signatures
+);
+
+-- Multimap: digest -> multiple non-transferable receipts
+-- ReDB: NONTRANS_RCTS: MultimapTableDefinition<&[u8], &[u8]>
+CREATE TABLE nontrans_receipts (
+    digest BYTEA NOT NULL,
+    receipt_data BYTEA NOT NULL,  -- rkyv serialized Nontransferable
+    PRIMARY KEY (digest, receipt_data)
+);
+
+-- Multimap: digest -> multiple transferable receipts
+-- ReDB: TRANS_RCTS: MultimapTableDefinition<&[u8], &[u8]>
+CREATE TABLE trans_receipts (
+    digest BYTEA NOT NULL,
+    receipt_data BYTEA NOT NULL,  -- rkyv serialized Transferable
+    PRIMARY KEY (digest, receipt_data)
+);
+
+-- Maps digest -> seal data
+-- ReDB: SEALS: TableDefinition<&[u8], &[u8]>
+CREATE TABLE seals (
+    digest BYTEA PRIMARY KEY,
+    seal_data BYTEA NOT NULL  -- rkyv serialized SourceSeal
+);
+
+-- ===========================================
+-- TEL Tables (TelEventDatabase)
+-- ===========================================
+
+-- TEL events storage
+-- ReDB: EVENTS: TableDefinition<&[u8], &[u8]>
+CREATE TABLE tel_events (
+    digest BYTEA PRIMARY KEY,
+    event_data BYTEA NOT NULL  -- CBOR serialized VerifiableEvent
+);
+
+-- VC TEL index: (vc_identifier, sn) -> event_digest
+-- ReDB: VC_TELS: TableDefinition<(&str, u64), &[u8]>
+CREATE TABLE vc_tels (
+    identifier TEXT NOT NULL,
+    sn BIGINT NOT NULL,
+    digest BYTEA NOT NULL,
+    PRIMARY KEY (identifier, sn)
+);
+CREATE INDEX idx_vc_tels_identifier ON vc_tels(identifier);
+
+-- Management TEL index: (registry_identifier, sn) -> event_digest
+-- ReDB: MANAGEMENT_TELS: TableDefinition<(&str, u64), &[u8]>
+CREATE TABLE management_tels (
+    identifier TEXT NOT NULL,
+    sn BIGINT NOT NULL,
+    digest BYTEA NOT NULL,
+    PRIMARY KEY (identifier, sn)
+);
+CREATE INDEX idx_management_tels_identifier ON management_tels(identifier);
+
+-- ===========================================
+-- Escrow Tables
+-- ===========================================
+
+-- Unified escrow table (replaces dynamic MultimapTableDefinition per escrow type)
+-- ReDB: sn_key_table: MultimapTableDefinition<(&str, u64), &[u8]>
+CREATE TABLE escrow_events (
+    escrow_type TEXT NOT NULL,  -- 'partially_signed', 'out_of_order', 'partially_witnessed', etc.
+    identifier TEXT NOT NULL,
+    sn BIGINT NOT NULL,
+    digest BYTEA NOT NULL,
+    PRIMARY KEY (escrow_type, identifier, sn, digest)  -- Allows multiple digests per (type, id, sn)
+);
+CREATE INDEX idx_escrow_lookup ON escrow_events(escrow_type, identifier, sn);
+
+-- Escrow timestamps
+-- ReDB: dts_table: TableDefinition<&[u8], u64>
+CREATE TABLE escrow_timestamps (
+    digest BYTEA PRIMARY KEY,
+    timestamp_secs BIGINT NOT NULL  -- seconds since UNIX_EPOCH
+);
+
+-- ===========================================
+-- OOBI Tables
+-- ===========================================
+
+-- Location scheme OOBIs: (eid, scheme) -> OOBI data
+CREATE TABLE location_oobis (
+    eid TEXT NOT NULL,
+    scheme TEXT NOT NULL,
+    oobi_data BYTEA NOT NULL,
+    PRIMARY KEY (eid, scheme)
+);
+
+-- End role OOBIs: (cid, role) -> multiple OOBIs
+CREATE TABLE end_role_oobis (
+    id SERIAL PRIMARY KEY,
+    cid TEXT NOT NULL,
+    role TEXT NOT NULL,
+    eid TEXT NOT NULL,
+    oobi_data BYTEA NOT NULL
+);
+CREATE INDEX idx_end_role_lookup ON end_role_oobis(cid, role);
+
+
+-- ===========================================
+-- KSN Tables
+-- ===========================================
+
+-- Maps digest -> serialized SignedReply (KSN log)
+CREATE TABLE ksns (
+    digest BYTEA PRIMARY KEY,
+    ksn_data BYTEA NOT NULL  -- CBOR serialized SignedReply
+);
+
+-- Maps (about_who, from_who) -> digest (accepted KSN index)
+CREATE TABLE accepted_ksns (
+    about_who TEXT NOT NULL,
+    from_who  TEXT NOT NULL,
+    digest    BYTEA NOT NULL,
+    PRIMARY KEY (about_who, from_who)
+);

--- a/keriox_core/src/database/postgres/mod.rs
+++ b/keriox_core/src/database/postgres/mod.rs
@@ -28,8 +28,12 @@ mod escrow_database;
 #[cfg(feature = "query")]
 mod ksn_log;
 mod loging;
+#[cfg(feature = "oobi-manager")]
+pub mod oobi_storage;
 
 pub use loging::PostgresLogDatabase;
+#[cfg(feature = "oobi-manager")]
+pub use oobi_storage::PostgresOobiStorage;
 
 use super::{timestamped::TimestampedSignedEventMessage, QueryParameters};
 

--- a/keriox_core/src/database/postgres/mod.rs
+++ b/keriox_core/src/database/postgres/mod.rs
@@ -1,0 +1,591 @@
+use std::sync::Arc;
+
+use cesrox::primitives::CesrPrimitive;
+use said::{sad::SerializationFormats, SelfAddressingIdentifier};
+use sqlx::{postgres::PgPoolOptions, PgPool, Row};
+
+#[cfg(feature = "query")]
+use crate::query::reply_event::SignedReply;
+use crate::{
+    database::{postgres::error::PostgresError, rkyv_adapter, EventDatabase, LogDatabase},
+    event::{receipt::Receipt, KeyEvent},
+    event_message::{
+        msg::KeriEvent,
+        signature::{Nontransferable, Transferable},
+        signed_event_message::{
+            SignedEventMessage, SignedNontransferableReceipt, SignedTransferableReceipt,
+        },
+    },
+    prefix::IdentifierPrefix,
+    state::IdentifierState,
+};
+
+#[cfg(feature = "query")]
+use ksn_log::AcceptedKsn;
+
+mod error;
+mod escrow_database;
+#[cfg(feature = "query")]
+mod ksn_log;
+mod loging;
+
+pub use loging::PostgresLogDatabase;
+
+use super::{timestamped::TimestampedSignedEventMessage, QueryParameters};
+
+pub struct PostgresDatabase {
+    pub(crate) pool: PgPool,
+    pub(crate) log_db: Arc<PostgresLogDatabase>,
+    #[cfg(feature = "query")]
+    accepted_rpy: Arc<AcceptedKsn>,
+}
+
+impl PostgresDatabase {
+    pub async fn new(database_url: &str) -> Result<Self, PostgresError> {
+        let pool = PgPoolOptions::new()
+            .max_connections(10)
+            .connect(database_url)
+            .await?;
+
+        let log_db = Arc::new(PostgresLogDatabase::new(pool.clone()));
+
+        #[cfg(feature = "query")]
+        let accepted_rpy = Arc::new(AcceptedKsn::new(pool.clone()));
+
+        Ok(Self {
+            pool,
+            log_db,
+            #[cfg(feature = "query")]
+            accepted_rpy,
+        })
+    }
+
+    pub async fn run_migrations(&self) -> Result<(), PostgresError> {
+        sqlx::migrate!("src/database/postgres/migrations")
+            .run(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn update_key_state(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        event: &KeriEvent<KeyEvent>,
+    ) -> Result<(), PostgresError> {
+        let prefix = event.data.prefix.to_str();
+
+        let row = sqlx::query("SELECT state_data FROM key_states WHERE identifier = $1")
+            .bind(&prefix)
+            .fetch_optional(&mut **tx)
+            .await?;
+
+        let current_state = match row {
+            Some(row) => {
+                let bytes: Vec<u8> = row.get("state_data");
+                rkyv_adapter::deserialize_identifier_state(&bytes)?
+            }
+            None => IdentifierState::default(),
+        };
+
+        let new_state = current_state
+            .apply(event)
+            .map_err(|_| PostgresError::AlreadySaved(event.digest().unwrap()))?;
+        let state_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&new_state)?;
+
+        sqlx::query(
+            "INSERT INTO key_states (identifier, state_data) VALUES ($1, $2) \
+             ON CONFLICT (identifier) DO UPDATE SET state_data = $2",
+        )
+        .bind(&prefix)
+        .bind(state_bytes.as_ref())
+        .execute(&mut **tx)
+        .await?;
+
+        Ok(())
+    }
+
+    fn get_event_digest(
+        &self,
+        identifier: &IdentifierPrefix,
+        sn: u64,
+    ) -> Result<Option<SelfAddressingIdentifier>, PostgresError> {
+        async_std::task::block_on(async {
+            let row = sqlx::query("SELECT digest FROM kels WHERE identifier = $1 AND sn = $2")
+                .bind(identifier.to_str())
+                .bind(sn as i64)
+                .fetch_optional(&self.pool)
+                .await?;
+
+            if let Some(row) = row {
+                let digest_bytes: Vec<u8> = row.get("digest");
+                let digest = rkyv_adapter::deserialize_said(&digest_bytes)?;
+                Ok(Some(digest))
+            } else {
+                Ok(None)
+            }
+        })
+    }
+
+    fn get_nontrans_receipts_range(
+        &self,
+        id: &str,
+        start: u64,
+        limit: u64,
+    ) -> Result<Vec<SignedNontransferableReceipt>, PostgresError> {
+        async_std::task::block_on(async {
+            let rows = if limit == u64::MAX {
+                sqlx::query(
+                    "SELECT k.sn, k.digest, nr.receipt_data \
+                     FROM kels k \
+                     LEFT JOIN nontrans_receipts nr ON k.digest = nr.digest \
+                     WHERE k.identifier = $1 AND k.sn >= $2 \
+                     ORDER BY k.sn ASC",
+                )
+                .bind(id)
+                .bind(start as i64)
+                .fetch_all(&self.pool)
+                .await?
+            } else {
+                let end_sn = start.saturating_add(limit) as i64;
+                sqlx::query(
+                    "SELECT k.sn, k.digest, nr.receipt_data \
+                     FROM kels k \
+                     LEFT JOIN nontrans_receipts nr ON k.digest = nr.digest \
+                     WHERE k.identifier = $1 AND k.sn >= $2 AND k.sn < $3 \
+                     ORDER BY k.sn ASC",
+                )
+                .bind(id)
+                .bind(start as i64)
+                .bind(end_sn)
+                .fetch_all(&self.pool)
+                .await?
+            };
+
+            let mut grouped: std::collections::BTreeMap<u64, (Vec<u8>, Vec<Nontransferable>)> =
+                std::collections::BTreeMap::new();
+
+            for row in rows {
+                let sn: i64 = row.get("sn");
+                let digest_bytes: Vec<u8> = row.get("digest");
+                let receipt_data: Option<Vec<u8>> = row.get("receipt_data");
+
+                let entry = grouped
+                    .entry(sn as u64)
+                    .or_insert_with(|| (digest_bytes, Vec::new()));
+
+                if let Some(bytes) = receipt_data {
+                    if let Ok(nt) = rkyv_adapter::deserialize_nontransferable(&bytes) {
+                        entry.1.push(nt);
+                    }
+                }
+            }
+
+            let identifier: IdentifierPrefix = id.parse().unwrap();
+            let receipts = grouped
+                .into_iter()
+                .map(|(sn, (digest_bytes, nontrans))| {
+                    let said = rkyv_adapter::deserialize_said(&digest_bytes).unwrap();
+                    let rct =
+                        Receipt::new(SerializationFormats::JSON, said, identifier.clone(), sn);
+                    SignedNontransferableReceipt {
+                        body: rct,
+                        signatures: nontrans,
+                    }
+                })
+                .collect();
+
+            Ok(receipts)
+        })
+    }
+
+    async fn save_to_kel(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        event: &KeriEvent<KeyEvent>,
+    ) -> Result<(), PostgresError> {
+        let prefix = event.data.prefix.to_str();
+        let digest = event.digest().map_err(|_| PostgresError::MissingDigest)?;
+        let sn = event.data.sn as i64;
+        let serialized_digest = rkyv_adapter::serialize_said(&digest)?;
+
+        sqlx::query(
+            "INSERT INTO kels (identifier, sn, digest) VALUES ($1, $2, $3) \
+             ON CONFLICT (identifier, sn) DO NOTHING",
+        )
+        .bind(&prefix)
+        .bind(sn)
+        .bind(serialized_digest.as_ref())
+        .execute(&mut **tx)
+        .await?;
+
+        Ok(())
+    }
+
+    fn get_kel(
+        &self,
+        id: &IdentifierPrefix,
+        from: u64,
+        limit: u64,
+    ) -> Result<Vec<TimestampedSignedEventMessage>, PostgresError> {
+        let prefix = id.to_str();
+        let from_sn = from as i64;
+
+        async_std::task::block_on(async {
+            let rows = if limit == u64::MAX {
+                sqlx::query(
+                    "SELECT digest FROM kels WHERE identifier = $1 AND sn >= $2 ORDER BY sn ASC",
+                )
+                .bind(&prefix)
+                .bind(from_sn)
+                .fetch_all(&self.pool)
+                .await?
+            } else {
+                let end_sn = from.saturating_add(limit) as i64;
+                sqlx::query(
+                    "SELECT digest FROM kels WHERE identifier = $1 AND sn >= $2 AND sn < $3 ORDER BY sn ASC",
+                )
+                .bind(&prefix)
+                .bind(from_sn)
+                .bind(end_sn)
+                .fetch_all(&self.pool)
+                .await?
+            };
+
+            let mut events = Vec::new();
+            for row in rows {
+                let digest_bytes: Vec<u8> = row.get("digest");
+                let said = rkyv_adapter::deserialize_said(&digest_bytes)?;
+                if let Some(timestamped_event) = self.log_db.get_signed_event(&said)? {
+                    events.push(timestamped_event);
+                }
+            }
+            Ok(events)
+        })
+    }
+}
+
+impl EventDatabase for PostgresDatabase {
+    type Error = PostgresError;
+    type LogDatabaseType = PostgresLogDatabase;
+
+    fn get_log_db(&self) -> Arc<Self::LogDatabaseType> {
+        self.log_db.clone()
+    }
+
+    fn add_kel_finalized_event(
+        &self,
+        signed_event: SignedEventMessage,
+        _id: &IdentifierPrefix,
+    ) -> Result<(), Self::Error> {
+        async_std::task::block_on(async {
+            let mut tx = self.pool.begin().await?;
+
+            self.update_key_state(&mut tx, &signed_event.event_message)
+                .await?;
+            self.save_to_kel(&mut tx, &signed_event.event_message)
+                .await?;
+            self.log_db
+                .log_event_with_tx(&mut tx, &signed_event)
+                .await?;
+
+            tx.commit().await?;
+            Ok(())
+        })
+    }
+
+    fn add_receipt_t(
+        &self,
+        receipt: SignedTransferableReceipt,
+        _id: &IdentifierPrefix,
+    ) -> Result<(), Self::Error> {
+        let digest = receipt.body.receipted_event_digest;
+        let transferable = Transferable::Seal(receipt.validator_seal, receipt.signatures);
+        self.log_db.insert_trans_receipt(&digest, &[transferable])
+    }
+
+    fn add_receipt_nt(
+        &self,
+        receipt: SignedNontransferableReceipt,
+        _id: &IdentifierPrefix,
+    ) -> Result<(), Self::Error> {
+        let receipted_event_digest = receipt.body.receipted_event_digest;
+        let receipts = receipt.signatures;
+        self.log_db
+            .insert_nontrans_receipt(&receipted_event_digest, &receipts)
+    }
+
+    fn get_key_state(&self, id: &IdentifierPrefix) -> Option<IdentifierState> {
+        let key = id.to_str();
+        let row = async_std::task::block_on(
+            sqlx::query("SELECT state_data FROM key_states WHERE identifier = $1")
+                .bind(&key)
+                .fetch_optional(&self.pool),
+        )
+        .ok()??;
+
+        let bytes: Vec<u8> = row.get("state_data");
+        Some(rkyv_adapter::deserialize_identifier_state(&bytes).ok()?)
+    }
+
+    fn get_kel_finalized_events(
+        &self,
+        params: QueryParameters,
+    ) -> Option<impl DoubleEndedIterator<Item = TimestampedSignedEventMessage>> {
+        let result = match params {
+            QueryParameters::BySn { id, sn } => self.get_kel(&id, sn, 1),
+            QueryParameters::Range { id, start, limit } => self.get_kel(&id, start, limit),
+            QueryParameters::All { id } => self.get_kel(id, 0, u64::MAX),
+        };
+
+        match result {
+            Ok(kel) if kel.is_empty() => None,
+            Ok(kel) => Some(kel.into_iter()),
+            Err(_) => None::<std::vec::IntoIter<TimestampedSignedEventMessage>>,
+        }
+    }
+
+    fn get_receipts_t(
+        &self,
+        params: QueryParameters,
+    ) -> Option<impl DoubleEndedIterator<Item = Transferable>> {
+        match params {
+            QueryParameters::BySn { id, sn } => {
+                if let Ok(Some(said)) = self.get_event_digest(&id, sn) {
+                    let receipts = self.log_db.get_trans_receipts(&said).ok()?;
+                    Some(receipts.collect::<Vec<_>>().into_iter())
+                } else {
+                    None
+                }
+            }
+            QueryParameters::Range { .. } => todo!(),
+            QueryParameters::All { .. } => todo!(),
+        }
+    }
+
+    fn get_receipts_nt(
+        &self,
+        params: QueryParameters,
+    ) -> Option<impl DoubleEndedIterator<Item = SignedNontransferableReceipt>> {
+        match params {
+            QueryParameters::BySn { id, sn } => self
+                .get_nontrans_receipts_range(&id.to_str(), sn, 1)
+                .ok()
+                .map(|e| e.into_iter()),
+            QueryParameters::Range { id, start, limit } => self
+                .get_nontrans_receipts_range(&id.to_str(), start, limit)
+                .ok()
+                .map(|e| e.into_iter()),
+            QueryParameters::All { id } => self
+                .get_nontrans_receipts_range(&id.to_str(), 0, u64::MAX)
+                .ok()
+                .map(|e| e.into_iter()),
+        }
+    }
+
+    fn accept_to_kel(&self, event: &KeriEvent<KeyEvent>) -> Result<(), Self::Error> {
+        async_std::task::block_on(async {
+            let mut tx = self.pool.begin().await?;
+
+            self.update_key_state(&mut tx, event).await?;
+            self.save_to_kel(&mut tx, event).await?;
+
+            tx.commit().await?;
+            Ok(())
+        })
+    }
+
+    #[cfg(feature = "query")]
+    fn save_reply(&self, reply: SignedReply) -> Result<(), Self::Error> {
+        self.accepted_rpy.insert(reply)
+    }
+
+    #[cfg(feature = "query")]
+    fn get_reply(&self, id: &IdentifierPrefix, from_who: &IdentifierPrefix) -> Option<SignedReply> {
+        self.accepted_rpy.get(id, from_who).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn get_database_url() -> String {
+        std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://postgres:postgres@localhost:5432/keri_test".to_string())
+    }
+
+    #[async_std::test]
+    #[ignore]
+    async fn test_postgres_migrations() {
+        let db = PostgresDatabase::new(&get_database_url())
+            .await
+            .expect("Failed to connect to database");
+
+        db.run_migrations().await.expect("Failed to run migrations");
+
+        println!("Migrations completed successfully!");
+    }
+
+    #[cfg(all(feature = "mailbox", feature = "oobi-manager"))]
+    #[async_std::test]
+    #[ignore]
+    async fn test_simple_controller_with_postgres() {
+        use crate::{
+            actor::simple_controller::SimpleController, oobi_manager::OobiManager,
+            processor::escrow::EscrowConfig, signer::CryptoBox,
+        };
+        use std::sync::Mutex;
+
+        let db = PostgresDatabase::new(&get_database_url())
+            .await
+            .expect("Failed to connect to database");
+
+        db.run_migrations().await.expect("Failed to run migrations");
+
+        let db = Arc::new(db);
+
+        let pool = sqlx::PgPool::connect(&get_database_url())
+            .await
+            .expect("Failed to create pool");
+        let oobi_storage = PostgresOobiStorage::new(pool);
+        let oobi_manager = OobiManager::new_with_storage(oobi_storage);
+
+        let key_manager = Arc::new(Mutex::new(CryptoBox::new().unwrap()));
+
+        let controller = SimpleController::new_with_oobi_manager(
+            db,
+            key_manager,
+            oobi_manager,
+            EscrowConfig::default(),
+        );
+
+        assert!(
+            controller.is_ok(),
+            "Failed to create SimpleController with Postgres"
+        );
+
+        println!("SimpleController with Postgres created successfully!");
+    }
+
+    #[cfg(all(feature = "mailbox", feature = "oobi-manager"))]
+    #[async_std::test]
+    #[ignore]
+    async fn test_postgres_incept() {
+        use crate::{
+            actor::simple_controller::SimpleController, oobi_manager::OobiManager,
+            processor::escrow::EscrowConfig, signer::CryptoBox,
+        };
+        use std::sync::Mutex;
+
+        let db = PostgresDatabase::new(&get_database_url())
+            .await
+            .expect("Failed to connect to database");
+
+        db.run_migrations().await.expect("Failed to run migrations");
+
+        let db = Arc::new(db);
+
+        let pool = sqlx::PgPool::connect(&get_database_url())
+            .await
+            .expect("Failed to create pool");
+        let oobi_storage = PostgresOobiStorage::new(pool);
+        let oobi_manager = OobiManager::new_with_storage(oobi_storage);
+
+        let key_manager = Arc::new(Mutex::new(CryptoBox::new().unwrap()));
+
+        let mut controller = SimpleController::new_with_oobi_manager(
+            db,
+            key_manager,
+            oobi_manager,
+            EscrowConfig::default(),
+        )
+        .expect("Failed to create SimpleController");
+
+        let signed_icp = controller
+            .incept(None, None, None)
+            .expect("Failed to incept");
+
+        println!(
+            "Inception event created: {:?}",
+            signed_icp.event_message.data.get_prefix()
+        );
+
+        let state = controller.get_state();
+        assert!(state.is_some(), "State should exist after inception");
+
+        let state = state.unwrap();
+        assert_eq!(state.sn, 0, "Inception event should have sn 0");
+        assert_eq!(
+            state.prefix,
+            signed_icp.event_message.data.get_prefix(),
+            "State prefix should match inception prefix"
+        );
+
+        println!("Inception test passed! Prefix: {}", controller.prefix());
+    }
+
+    #[cfg(all(feature = "mailbox", feature = "oobi-manager"))]
+    #[async_std::test]
+    #[ignore]
+    async fn test_postgres_get_kel() {
+        use crate::{
+            actor::simple_controller::SimpleController, database::QueryParameters,
+            event_message::EventTypeTag, oobi_manager::OobiManager,
+            processor::escrow::EscrowConfig, signer::CryptoBox,
+        };
+        use std::sync::Mutex;
+
+        let db = PostgresDatabase::new(&get_database_url())
+            .await
+            .expect("Failed to connect to database");
+        db.run_migrations().await.expect("Failed to run migrations");
+        let db = Arc::new(db);
+
+        let pool = sqlx::PgPool::connect(&get_database_url())
+            .await
+            .expect("Failed to create pool");
+        let oobi_storage = PostgresOobiStorage::new(pool);
+        let oobi_manager = OobiManager::new_with_storage(oobi_storage);
+        let key_manager = Arc::new(Mutex::new(CryptoBox::new().unwrap()));
+
+        let mut controller = SimpleController::new_with_oobi_manager(
+            db.clone(),
+            key_manager,
+            oobi_manager,
+            EscrowConfig::default(),
+        )
+        .expect("Failed to create SimpleController");
+
+        let signed_icp = controller
+            .incept(None, None, None)
+            .expect("Failed to incept");
+
+        let prefix = signed_icp.event_message.data.get_prefix();
+
+        let kel_sn0 = db.get_kel(&prefix, 0, 1).expect("get_kel failed");
+        assert_eq!(kel_sn0.len(), 1);
+
+        let full_kel: Vec<_> = db
+            .get_kel_finalized_events(QueryParameters::All { id: &prefix })
+            .expect("Full KEL should exist")
+            .collect();
+        assert_eq!(full_kel.len(), 1);
+
+        let by_sn: Vec<_> = db
+            .get_kel_finalized_events(QueryParameters::BySn {
+                id: prefix.clone(),
+                sn: 0,
+            })
+            .expect("BySn should return event")
+            .collect();
+        assert_eq!(by_sn.len(), 1);
+
+        let empty = db.get_kel_finalized_events(QueryParameters::BySn {
+            id: prefix.clone(),
+            sn: 99,
+        });
+        assert!(empty.is_none());
+
+        println!("test_postgres_get_kel passed! Prefix: {}", prefix);
+    }
+}

--- a/keriox_core/src/database/postgres/mod.rs
+++ b/keriox_core/src/database/postgres/mod.rs
@@ -408,168 +408,94 @@ impl EventDatabase for PostgresDatabase {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        actor::event_generator,
+        database::QueryParameters,
+        event_message::{
+            cesr_adapter::{parse_event_type, EventType},
+            EventTypeTag,
+        },
+        prefix::{BasicPrefix, IndexedSignature, SelfSigningPrefix},
+        signer::{CryptoBox, KeyManager},
+    };
 
     fn get_database_url() -> String {
         std::env::var("DATABASE_URL")
             .unwrap_or_else(|_| "postgres://postgres:postgres@localhost:5432/keri_test".to_string())
     }
 
+    async fn setup_db() -> Arc<PostgresDatabase> {
+        let db = Arc::new(
+            PostgresDatabase::new(&get_database_url())
+                .await
+                .expect("Failed to connect to database"),
+        );
+        db.run_migrations().await.expect("Failed to run migrations");
+        db
+    }
+
+    fn make_signed_icp() -> (
+        crate::prefix::IdentifierPrefix,
+        crate::event_message::signed_event_message::SignedEventMessage,
+    ) {
+        let key_manager = CryptoBox::new().unwrap();
+        let pk = BasicPrefix::Ed25519(key_manager.public_key());
+        let npk = BasicPrefix::Ed25519(key_manager.next_public_key());
+
+        let icp_str = event_generator::incept(vec![pk], vec![npk], vec![], 0, None).unwrap();
+        let sig = SelfSigningPrefix::Ed25519Sha512(key_manager.sign(icp_str.as_bytes()).unwrap());
+        let ke = match parse_event_type(icp_str.as_bytes()).unwrap() {
+            EventType::KeyEvent(ke) => ke,
+            _ => panic!("Expected key event"),
+        };
+        let signed = ke.sign(vec![IndexedSignature::new_both_same(sig, 0)], None, None);
+        let prefix = signed.event_message.data.get_prefix();
+        (prefix, signed)
+    }
+
     #[async_std::test]
     #[ignore]
     async fn test_postgres_migrations() {
-        let db = PostgresDatabase::new(&get_database_url())
-            .await
-            .expect("Failed to connect to database");
-
-        db.run_migrations().await.expect("Failed to run migrations");
-
+        setup_db().await;
         println!("Migrations completed successfully!");
     }
 
-    #[cfg(all(feature = "mailbox", feature = "oobi-manager"))]
-    #[async_std::test]
-    #[ignore]
-    async fn test_simple_controller_with_postgres() {
-        use crate::{
-            actor::simple_controller::SimpleController, oobi_manager::OobiManager,
-            processor::escrow::EscrowConfig, signer::CryptoBox,
-        };
-        use std::sync::Mutex;
-
-        let db = PostgresDatabase::new(&get_database_url())
-            .await
-            .expect("Failed to connect to database");
-
-        db.run_migrations().await.expect("Failed to run migrations");
-
-        let db = Arc::new(db);
-
-        let pool = sqlx::PgPool::connect(&get_database_url())
-            .await
-            .expect("Failed to create pool");
-        let oobi_storage = PostgresOobiStorage::new(pool);
-        let oobi_manager = OobiManager::new_with_storage(oobi_storage);
-
-        let key_manager = Arc::new(Mutex::new(CryptoBox::new().unwrap()));
-
-        let controller = SimpleController::new_with_oobi_manager(
-            db,
-            key_manager,
-            oobi_manager,
-            EscrowConfig::default(),
-        );
-
-        assert!(
-            controller.is_ok(),
-            "Failed to create SimpleController with Postgres"
-        );
-
-        println!("SimpleController with Postgres created successfully!");
-    }
-
-    #[cfg(all(feature = "mailbox", feature = "oobi-manager"))]
     #[async_std::test]
     #[ignore]
     async fn test_postgres_incept() {
-        use crate::{
-            actor::simple_controller::SimpleController, oobi_manager::OobiManager,
-            processor::escrow::EscrowConfig, signer::CryptoBox,
-        };
-        use std::sync::Mutex;
+        let db = setup_db().await;
+        let (prefix, signed_event) = make_signed_icp();
 
-        let db = PostgresDatabase::new(&get_database_url())
-            .await
-            .expect("Failed to connect to database");
+        db.add_kel_finalized_event(signed_event, &prefix)
+            .expect("Failed to store inception event");
 
-        db.run_migrations().await.expect("Failed to run migrations");
-
-        let db = Arc::new(db);
-
-        let pool = sqlx::PgPool::connect(&get_database_url())
-            .await
-            .expect("Failed to create pool");
-        let oobi_storage = PostgresOobiStorage::new(pool);
-        let oobi_manager = OobiManager::new_with_storage(oobi_storage);
-
-        let key_manager = Arc::new(Mutex::new(CryptoBox::new().unwrap()));
-
-        let mut controller = SimpleController::new_with_oobi_manager(
-            db,
-            key_manager,
-            oobi_manager,
-            EscrowConfig::default(),
-        )
-        .expect("Failed to create SimpleController");
-
-        let signed_icp = controller
-            .incept(None, None, None)
-            .expect("Failed to incept");
-
-        println!(
-            "Inception event created: {:?}",
-            signed_icp.event_message.data.get_prefix()
-        );
-
-        let state = controller.get_state();
-        assert!(state.is_some(), "State should exist after inception");
-
-        let state = state.unwrap();
-        assert_eq!(state.sn, 0, "Inception event should have sn 0");
-        assert_eq!(
-            state.prefix,
-            signed_icp.event_message.data.get_prefix(),
-            "State prefix should match inception prefix"
-        );
-
-        println!("Inception test passed! Prefix: {}", controller.prefix());
+        let state = db
+            .get_key_state(&prefix)
+            .expect("State should exist after inception");
+        assert_eq!(state.sn, 0);
     }
 
-    #[cfg(all(feature = "mailbox", feature = "oobi-manager"))]
     #[async_std::test]
     #[ignore]
     async fn test_postgres_get_kel() {
-        use crate::{
-            actor::simple_controller::SimpleController, database::QueryParameters,
-            event_message::EventTypeTag, oobi_manager::OobiManager,
-            processor::escrow::EscrowConfig, signer::CryptoBox,
-        };
-        use std::sync::Mutex;
+        let db = setup_db().await;
+        let (prefix, signed_event) = make_signed_icp();
 
-        let db = PostgresDatabase::new(&get_database_url())
-            .await
-            .expect("Failed to connect to database");
-        db.run_migrations().await.expect("Failed to run migrations");
-        let db = Arc::new(db);
+        db.add_kel_finalized_event(signed_event, &prefix)
+            .expect("Failed to store inception event");
 
-        let pool = sqlx::PgPool::connect(&get_database_url())
-            .await
-            .expect("Failed to create pool");
-        let oobi_storage = PostgresOobiStorage::new(pool);
-        let oobi_manager = OobiManager::new_with_storage(oobi_storage);
-        let key_manager = Arc::new(Mutex::new(CryptoBox::new().unwrap()));
+        let kel = db.get_kel(&prefix, 0, 1).expect("get_kel failed");
+        assert_eq!(kel.len(), 1);
+        assert_eq!(
+            kel[0].signed_event_message.event_message.event_type,
+            EventTypeTag::Icp
+        );
 
-        let mut controller = SimpleController::new_with_oobi_manager(
-            db.clone(),
-            key_manager,
-            oobi_manager,
-            EscrowConfig::default(),
-        )
-        .expect("Failed to create SimpleController");
-
-        let signed_icp = controller
-            .incept(None, None, None)
-            .expect("Failed to incept");
-
-        let prefix = signed_icp.event_message.data.get_prefix();
-
-        let kel_sn0 = db.get_kel(&prefix, 0, 1).expect("get_kel failed");
-        assert_eq!(kel_sn0.len(), 1);
-
-        let full_kel: Vec<_> = db
+        let full: Vec<_> = db
             .get_kel_finalized_events(QueryParameters::All { id: &prefix })
             .expect("Full KEL should exist")
             .collect();
-        assert_eq!(full_kel.len(), 1);
+        assert_eq!(full.len(), 1);
 
         let by_sn: Vec<_> = db
             .get_kel_finalized_events(QueryParameters::BySn {
@@ -580,12 +506,11 @@ mod tests {
             .collect();
         assert_eq!(by_sn.len(), 1);
 
-        let empty = db.get_kel_finalized_events(QueryParameters::BySn {
-            id: prefix.clone(),
-            sn: 99,
-        });
-        assert!(empty.is_none());
-
-        println!("test_postgres_get_kel passed! Prefix: {}", prefix);
+        assert!(db
+            .get_kel_finalized_events(QueryParameters::BySn {
+                id: prefix.clone(),
+                sn: 99
+            })
+            .is_none());
     }
 }

--- a/keriox_core/src/database/postgres/mod.rs
+++ b/keriox_core/src/database/postgres/mod.rs
@@ -33,6 +33,20 @@ pub use loging::PostgresLogDatabase;
 
 use super::{timestamped::TimestampedSignedEventMessage, QueryParameters};
 
+/// Configuration for the PostgreSQL connection pool.
+pub struct PostgresConfig {
+    /// Maximum number of connections in the pool.
+    pub max_connections: u32,
+}
+
+impl Default for PostgresConfig {
+    fn default() -> Self {
+        Self {
+            max_connections: 10,
+        }
+    }
+}
+
 pub struct PostgresDatabase {
     pub(crate) pool: PgPool,
     pub(crate) log_db: Arc<PostgresLogDatabase>,
@@ -42,8 +56,15 @@ pub struct PostgresDatabase {
 
 impl PostgresDatabase {
     pub async fn new(database_url: &str) -> Result<Self, PostgresError> {
+        Self::new_with_config(database_url, PostgresConfig::default()).await
+    }
+
+    pub async fn new_with_config(
+        database_url: &str,
+        config: PostgresConfig,
+    ) -> Result<Self, PostgresError> {
         let pool = PgPoolOptions::new()
-            .max_connections(10)
+            .max_connections(config.max_connections)
             .connect(database_url)
             .await?;
 

--- a/keriox_core/src/database/postgres/oobi_storage.rs
+++ b/keriox_core/src/database/postgres/oobi_storage.rs
@@ -1,0 +1,112 @@
+use super::error::PostgresError;
+use crate::oobi::{Role, Scheme};
+use crate::oobi_manager::storage::OobiStorageBackend;
+use crate::prefix::IdentifierPrefix;
+use crate::query::reply_event::{ReplyRoute, SignedReply};
+use sqlx::PgPool;
+
+pub struct PostgresOobiStorage {
+    pool: PgPool,
+}
+
+impl PostgresOobiStorage {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+impl OobiStorageBackend for PostgresOobiStorage {
+    type Error = PostgresError;
+
+    fn get_oobis_for_eid(&self, id: &IdentifierPrefix) -> Result<Vec<SignedReply>, Self::Error> {
+        async_std::task::block_on(async {
+            let rows: Vec<(Vec<u8>,)> =
+                sqlx::query_as(r#"SELECT oobi_data FROM location_oobis WHERE eid = $1"#)
+                    .bind(id.to_string())
+                    .fetch_all(&self.pool)
+                    .await?;
+
+            Ok(rows
+                .into_iter()
+                .filter_map(|(oobi_data,)| serde_cbor::from_slice(&oobi_data).ok())
+                .collect())
+        })
+    }
+
+    fn get_last_loc_scheme(
+        &self,
+        eid: &IdentifierPrefix,
+        scheme: &Scheme,
+    ) -> Result<Option<SignedReply>, Self::Error> {
+        async_std::task::block_on(async {
+            let row: Option<(Vec<u8>,)> = sqlx::query_as(
+                r#"SELECT oobi_data FROM location_oobis WHERE eid = $1 AND scheme = $2"#,
+            )
+            .bind(eid.to_string())
+            .bind(serde_json::to_string(scheme).unwrap())
+            .fetch_optional(&self.pool)
+            .await?;
+
+            Ok(row.and_then(|(oobi_data,)| serde_cbor::from_slice(&oobi_data).ok()))
+        })
+    }
+
+    fn get_end_role(
+        &self,
+        cid: &IdentifierPrefix,
+        role: Role,
+    ) -> Result<Option<Vec<SignedReply>>, Self::Error> {
+        async_std::task::block_on(async {
+            let rows: Vec<(Vec<u8>,)> = sqlx::query_as(
+                r#"SELECT oobi_data FROM end_role_oobis WHERE cid = $1 AND role = $2"#,
+            )
+            .bind(cid.to_string())
+            .bind(serde_json::to_string(&role).unwrap())
+            .fetch_all(&self.pool)
+            .await?;
+
+            if rows.is_empty() {
+                return Ok(None);
+            }
+
+            Ok(Some(
+                rows.into_iter()
+                    .filter_map(|(oobi_data,)| serde_cbor::from_slice(&oobi_data).ok())
+                    .collect(),
+            ))
+        })
+    }
+
+    fn save_oobi(&self, signed_reply: &SignedReply) -> Result<(), Self::Error> {
+        async_std::task::block_on(async {
+            match signed_reply.reply.get_route() {
+                ReplyRoute::LocScheme(loc_scheme) => {
+                    sqlx::query(
+                        r#"INSERT INTO location_oobis (eid, scheme, oobi_data)
+                           VALUES ($1, $2, $3)
+                           ON CONFLICT (eid, scheme) DO UPDATE SET oobi_data = $3"#,
+                    )
+                    .bind(loc_scheme.get_eid().to_string())
+                    .bind(serde_json::to_string(&loc_scheme.scheme).unwrap())
+                    .bind(serde_cbor::to_vec(signed_reply).unwrap())
+                    .execute(&self.pool)
+                    .await?;
+                }
+                ReplyRoute::EndRoleAdd(end_role) | ReplyRoute::EndRoleCut(end_role) => {
+                    sqlx::query(
+                        r#"INSERT INTO end_role_oobis (cid, role, eid, oobi_data)
+                           VALUES ($1, $2, $3, $4)"#,
+                    )
+                    .bind(end_role.cid.to_string())
+                    .bind(serde_json::to_string(&end_role.role).unwrap())
+                    .bind(end_role.eid.to_string())
+                    .bind(serde_cbor::to_vec(signed_reply).unwrap())
+                    .execute(&self.pool)
+                    .await?;
+                }
+                _ => {}
+            }
+            Ok(())
+        })
+    }
+}

--- a/keriox_core/src/database/postgres/oobi_storage.rs
+++ b/keriox_core/src/database/postgres/oobi_storage.rs
@@ -26,10 +26,9 @@ impl OobiStorageBackend for PostgresOobiStorage {
                     .fetch_all(&self.pool)
                     .await?;
 
-            Ok(rows
-                .into_iter()
-                .filter_map(|(oobi_data,)| serde_cbor::from_slice(&oobi_data).ok())
-                .collect())
+            rows.into_iter()
+                .map(|(oobi_data,)| serde_cbor::from_slice(&oobi_data).map_err(Into::into))
+                .collect::<Result<Vec<SignedReply>, Self::Error>>()
         })
     }
 
@@ -43,11 +42,12 @@ impl OobiStorageBackend for PostgresOobiStorage {
                 r#"SELECT oobi_data FROM location_oobis WHERE eid = $1 AND scheme = $2"#,
             )
             .bind(eid.to_string())
-            .bind(serde_json::to_string(scheme).unwrap())
+            .bind(serde_json::to_string(scheme)?)
             .fetch_optional(&self.pool)
             .await?;
 
-            Ok(row.and_then(|(oobi_data,)| serde_cbor::from_slice(&oobi_data).ok()))
+            row.map(|(oobi_data,)| serde_cbor::from_slice(&oobi_data).map_err(Into::into))
+                .transpose()
         })
     }
 
@@ -61,7 +61,7 @@ impl OobiStorageBackend for PostgresOobiStorage {
                 r#"SELECT oobi_data FROM end_role_oobis WHERE cid = $1 AND role = $2"#,
             )
             .bind(cid.to_string())
-            .bind(serde_json::to_string(&role).unwrap())
+            .bind(serde_json::to_string(&role)?)
             .fetch_all(&self.pool)
             .await?;
 
@@ -69,11 +69,11 @@ impl OobiStorageBackend for PostgresOobiStorage {
                 return Ok(None);
             }
 
-            Ok(Some(
-                rows.into_iter()
-                    .filter_map(|(oobi_data,)| serde_cbor::from_slice(&oobi_data).ok())
-                    .collect(),
-            ))
+            let replies = rows
+                .into_iter()
+                .map(|(oobi_data,)| serde_cbor::from_slice(&oobi_data).map_err(Into::into))
+                .collect::<Result<Vec<SignedReply>, Self::Error>>()?;
+            Ok(Some(replies))
         })
     }
 
@@ -87,8 +87,8 @@ impl OobiStorageBackend for PostgresOobiStorage {
                            ON CONFLICT (eid, scheme) DO UPDATE SET oobi_data = $3"#,
                     )
                     .bind(loc_scheme.get_eid().to_string())
-                    .bind(serde_json::to_string(&loc_scheme.scheme).unwrap())
-                    .bind(serde_cbor::to_vec(signed_reply).unwrap())
+                    .bind(serde_json::to_string(&loc_scheme.scheme)?)
+                    .bind(serde_cbor::to_vec(signed_reply)?)
                     .execute(&self.pool)
                     .await?;
                 }
@@ -98,9 +98,9 @@ impl OobiStorageBackend for PostgresOobiStorage {
                            VALUES ($1, $2, $3, $4)"#,
                     )
                     .bind(end_role.cid.to_string())
-                    .bind(serde_json::to_string(&end_role.role).unwrap())
+                    .bind(serde_json::to_string(&end_role.role)?)
                     .bind(end_role.eid.to_string())
-                    .bind(serde_cbor::to_vec(signed_reply).unwrap())
+                    .bind(serde_cbor::to_vec(signed_reply)?)
                     .execute(&self.pool)
                     .await?;
                 }

--- a/keriox_core/src/database/postgres/oobi_storage.rs
+++ b/keriox_core/src/database/postgres/oobi_storage.rs
@@ -92,7 +92,7 @@ impl OobiStorageBackend for PostgresOobiStorage {
                     .execute(&self.pool)
                     .await?;
                 }
-                ReplyRoute::EndRoleAdd(end_role) | ReplyRoute::EndRoleCut(end_role) => {
+                ReplyRoute::EndRoleAdd(end_role) => {
                     sqlx::query(
                         r#"INSERT INTO end_role_oobis (cid, role, eid, oobi_data)
                            VALUES ($1, $2, $3, $4)"#,
@@ -104,7 +104,22 @@ impl OobiStorageBackend for PostgresOobiStorage {
                     .execute(&self.pool)
                     .await?;
                 }
-                _ => {}
+                ReplyRoute::EndRoleCut(end_role) => {
+                    // TODO: EndRoleCut should DELETE the role from storage.
+                    // Currently inserts the Cut event, matching redb behaviour,
+                    // pending a proper removal implementation.
+                    sqlx::query(
+                        r#"INSERT INTO end_role_oobis (cid, role, eid, oobi_data)
+                           VALUES ($1, $2, $3, $4)"#,
+                    )
+                    .bind(end_role.cid.to_string())
+                    .bind(serde_json::to_string(&end_role.role)?)
+                    .bind(end_role.eid.to_string())
+                    .bind(serde_cbor::to_vec(signed_reply)?)
+                    .execute(&self.pool)
+                    .await?;
+                }
+                ReplyRoute::Ksn(_, _) => todo!(),
             }
             Ok(())
         })

--- a/keriox_core/src/database/redb/mod.rs
+++ b/keriox_core/src/database/redb/mod.rs
@@ -2,7 +2,7 @@ pub mod escrow_database;
 #[cfg(feature = "query")]
 pub(crate) mod ksn_log;
 pub mod loging;
-pub(crate) mod rkyv_adapter;
+pub(crate) use super::rkyv_adapter;
 
 /// Kel storage. (identifier, sn) -> event digest
 /// The `KELS` table links an identifier and sequence number to the digest of an event,

--- a/keriox_core/src/database/rkyv_adapter/mod.rs
+++ b/keriox_core/src/database/rkyv_adapter/mod.rs
@@ -1,0 +1,58 @@
+use rkyv::{util::AlignedVec, with::With};
+use said::SelfAddressingIdentifier;
+use said_wrapper::{ArchivedSAIDef, SAIDef};
+
+use crate::{
+    event::sections::seal::{ArchivedSourceSeal, SourceSeal},
+    event_message::signature::{
+        ArchivedNontransferable, ArchivedTransferable, Nontransferable, Transferable,
+    },
+    prefix::{attached_signature::ArchivedIndexedSignature, IndexedSignature},
+    state::IdentifierState,
+};
+
+pub(crate) mod said_wrapper;
+pub(crate) mod serialization_info_wrapper;
+
+pub fn serialize_said(said: &SelfAddressingIdentifier) -> Result<AlignedVec, rkyv::rancor::Error> {
+    Ok(rkyv::to_bytes(
+        With::<SelfAddressingIdentifier, SAIDef>::cast(said),
+    )?)
+}
+
+pub fn deserialize_said(bytes: &[u8]) -> Result<SelfAddressingIdentifier, rkyv::rancor::Error> {
+    let archived: &ArchivedSAIDef = rkyv::access(&bytes)?;
+    let deserialized: SelfAddressingIdentifier =
+        rkyv::deserialize(With::<ArchivedSAIDef, SAIDef>::cast(archived))?;
+    Ok(deserialized)
+}
+
+pub fn deserialize_nontransferable(bytes: &[u8]) -> Result<Nontransferable, rkyv::rancor::Error> {
+    let archived = rkyv::access::<ArchivedNontransferable, rkyv::rancor::Failure>(&bytes).unwrap();
+    rkyv::deserialize::<Nontransferable, rkyv::rancor::Error>(archived)
+}
+
+pub fn deserialize_transferable(bytes: &[u8]) -> Result<Transferable, rkyv::rancor::Error> {
+    let archived = rkyv::access::<ArchivedTransferable, rkyv::rancor::Failure>(&bytes).unwrap();
+    rkyv::deserialize::<Transferable, rkyv::rancor::Error>(archived)
+}
+
+pub fn deserialize_indexed_signatures(
+    bytes: &[u8],
+) -> Result<IndexedSignature, rkyv::rancor::Error> {
+    let archived = rkyv::access::<ArchivedIndexedSignature, rkyv::rancor::Error>(&bytes).unwrap();
+    rkyv::deserialize::<IndexedSignature, rkyv::rancor::Error>(archived)
+}
+
+pub fn deserialize_source_seal(bytes: &[u8]) -> Result<SourceSeal, rkyv::rancor::Error> {
+    let archived = rkyv::access::<ArchivedSourceSeal, rkyv::rancor::Error>(&bytes).unwrap();
+    rkyv::deserialize::<SourceSeal, rkyv::rancor::Error>(archived)
+}
+
+pub fn deserialize_identifier_state(bytes: &[u8]) -> Result<IdentifierState, rkyv::rancor::Error> {
+    let mut aligned_bytes =
+        AlignedVec::<{ std::mem::align_of::<IdentifierState>() }>::with_capacity(bytes.len());
+    aligned_bytes.extend_from_slice(bytes);
+
+    rkyv::from_bytes::<IdentifierState, rkyv::rancor::Error>(&aligned_bytes)
+}

--- a/keriox_core/src/database/rkyv_adapter/said_wrapper.rs
+++ b/keriox_core/src/database/rkyv_adapter/said_wrapper.rs
@@ -1,0 +1,141 @@
+use said::{
+    derivation::{HashFunction, HashFunctionCode},
+    SelfAddressingIdentifier,
+};
+
+use rkyv::{Archive, Deserialize, Serialize};
+
+#[derive(
+    Debug, Clone, Default, Eq, Hash, Archive, rkyv::Serialize, rkyv::Deserialize, PartialEq,
+)]
+#[rkyv(derive(Debug))]
+pub struct SaidValue {
+    #[rkyv(with = SAIDef)]
+    pub said: SelfAddressingIdentifier,
+}
+
+impl From<SelfAddressingIdentifier> for SaidValue {
+    fn from(value: SelfAddressingIdentifier) -> Self {
+        Self { said: value }
+    }
+}
+
+impl From<SaidValue> for SelfAddressingIdentifier {
+    fn from(value: SaidValue) -> Self {
+        value.said
+    }
+}
+
+impl serde::Serialize for SaidValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.said.serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for SaidValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        SelfAddressingIdentifier::deserialize(deserializer).map(|said| SaidValue { said })
+    }
+}
+
+#[derive(Archive, Serialize, Deserialize)]
+#[rkyv(remote = SelfAddressingIdentifier)]
+#[rkyv(derive(Debug))]
+pub(crate) struct SAIDef {
+    #[rkyv(with = HashFunctionDef)]
+    pub derivation: HashFunction,
+    pub digest: Vec<u8>,
+}
+
+impl From<SAIDef> for SelfAddressingIdentifier {
+    fn from(value: SAIDef) -> Self {
+        Self::new(value.derivation, value.digest)
+    }
+}
+
+#[derive(Archive, Serialize, Deserialize, PartialEq)]
+#[rkyv(remote = HashFunction)]
+#[rkyv(derive(Debug))]
+struct HashFunctionDef {
+    #[rkyv(getter = HashFunctionDef::get_code, with = HashFunctionCodeDef)]
+    pub f: HashFunctionCode,
+}
+
+impl HashFunctionDef {
+    fn get_code(foo: &HashFunction) -> HashFunctionCode {
+        foo.into()
+    }
+}
+
+impl From<HashFunctionDef> for HashFunction {
+    fn from(value: HashFunctionDef) -> Self {
+        value.f.into()
+    }
+}
+
+#[derive(Archive, Serialize, Deserialize, PartialEq)]
+#[rkyv(remote = HashFunctionCode)]
+#[rkyv(compare(PartialEq), derive(Debug))]
+enum HashFunctionCodeDef {
+    Blake3_256,
+    Blake2B256(Vec<u8>),
+    Blake2S256(Vec<u8>),
+    SHA3_256,
+    SHA2_256,
+    Blake3_512,
+    SHA3_512,
+    Blake2B512,
+    SHA2_512,
+}
+
+impl From<HashFunctionCodeDef> for HashFunctionCode {
+    fn from(value: HashFunctionCodeDef) -> Self {
+        match value {
+            HashFunctionCodeDef::Blake3_256 => HashFunctionCode::Blake3_256,
+            HashFunctionCodeDef::Blake2B256(vec) => HashFunctionCode::Blake2B256(vec),
+            HashFunctionCodeDef::Blake2S256(vec) => HashFunctionCode::Blake2S256(vec),
+            HashFunctionCodeDef::SHA3_256 => HashFunctionCode::SHA3_256,
+            HashFunctionCodeDef::SHA2_256 => HashFunctionCode::SHA2_256,
+            HashFunctionCodeDef::Blake3_512 => HashFunctionCode::Blake3_512,
+            HashFunctionCodeDef::SHA3_512 => HashFunctionCode::SHA3_512,
+            HashFunctionCodeDef::Blake2B512 => HashFunctionCode::Blake2B512,
+            HashFunctionCodeDef::SHA2_512 => HashFunctionCode::SHA2_512,
+        }
+    }
+}
+
+#[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+// #[rkyv(
+//     compare(PartialEq),
+//     derive(Debug),
+// )]
+struct OptionalSaid {
+    value: SaidValue,
+}
+
+#[test]
+fn test_rkyv_said_serialization() -> Result<(), rkyv::rancor::Failure> {
+    use rkyv::with::With;
+    let value: SelfAddressingIdentifier = "EJe_sKQb1otKrz6COIL8VFvBv3DEFvtKaVFGn1vm0IlL"
+        .parse()
+        .unwrap();
+
+    let bytes = rkyv::to_bytes(With::<SelfAddressingIdentifier, SAIDef>::cast(&value))?;
+    dbg!(&bytes);
+    let archived: &ArchivedSAIDef = rkyv::access(&bytes)?;
+
+    let deserialized: SelfAddressingIdentifier =
+        rkyv::deserialize(With::<ArchivedSAIDef, SAIDef>::cast(archived))?;
+
+    // let des = rkyv_adapter::deserialize_element::<ArchivedSAIDef, SAIDef, SelfAddressingIdentifier>(&bytes);
+
+    assert_eq!(value, deserialized);
+
+    Ok(())
+}

--- a/keriox_core/src/database/rkyv_adapter/serialization_info_wrapper.rs
+++ b/keriox_core/src/database/rkyv_adapter/serialization_info_wrapper.rs
@@ -1,0 +1,58 @@
+use said::{sad::SerializationFormats, version::SerializationInfo};
+
+#[derive(
+    Debug,
+    Clone,
+    serde::Serialize,
+    serde::Deserialize,
+    Default,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    PartialEq,
+)]
+pub(crate) struct SerializationInfoValue {
+    #[rkyv(with = SerializationInfoDef)]
+    info: SerializationInfo,
+}
+
+#[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize, PartialEq)]
+#[rkyv(remote = SerializationInfo)]
+pub(crate) struct SerializationInfoDef {
+    pub protocol_code: String,
+    pub major_version: u8,
+    pub minor_version: u8,
+    pub size: usize,
+    #[rkyv(with = SerializationFormatsDef)]
+    pub kind: SerializationFormats,
+}
+
+impl From<SerializationInfoDef> for SerializationInfo {
+    fn from(value: SerializationInfoDef) -> Self {
+        SerializationInfo {
+            protocol_code: value.protocol_code,
+            major_version: value.major_version,
+            minor_version: value.minor_version,
+            size: value.size,
+            kind: value.kind,
+        }
+    }
+}
+
+#[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize, PartialEq)]
+#[rkyv(remote = SerializationFormats)]
+pub enum SerializationFormatsDef {
+    JSON,
+    MGPK,
+    CBOR,
+}
+
+impl From<SerializationFormatsDef> for SerializationFormats {
+    fn from(value: SerializationFormatsDef) -> Self {
+        match value {
+            SerializationFormatsDef::JSON => Self::JSON,
+            SerializationFormatsDef::MGPK => Self::MGPK,
+            SerializationFormatsDef::CBOR => Self::CBOR,
+        }
+    }
+}

--- a/keriox_core/src/error/mod.rs
+++ b/keriox_core/src/error/mod.rs
@@ -2,10 +2,11 @@ use said::version::error::Error as VersionError;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+#[cfg(feature = "storage-redb")]
+use crate::database::redb::RedbError;
 use crate::{
-    database::redb::RedbError, event::sections::key_config::SignatureError,
-    event_message::cesr_adapter::ParseError, prefix::IdentifierPrefix,
-    processor::validator::VerificationError,
+    event::sections::key_config::SignatureError, event_message::cesr_adapter::ParseError,
+    prefix::IdentifierPrefix, processor::validator::VerificationError,
 };
 
 pub mod serializer_error;
@@ -128,6 +129,7 @@ impl From<said::error::Error> for Error {
     }
 }
 
+#[cfg(feature = "storage-redb")]
 impl From<RedbError> for Error {
     fn from(_: RedbError) -> Self {
         Error::DbError

--- a/keriox_core/src/error/mod.rs
+++ b/keriox_core/src/error/mod.rs
@@ -136,6 +136,13 @@ impl From<RedbError> for Error {
     }
 }
 
+#[cfg(feature = "oobi")]
+impl From<crate::oobi::error::OobiError> for Error {
+    fn from(e: crate::oobi::error::OobiError) -> Self {
+        Error::SemanticError(e.to_string())
+    }
+}
+
 impl From<crate::keys::KeysError> for Error {
     fn from(_: crate::keys::KeysError) -> Self {
         Error::SigningError

--- a/keriox_core/src/event/event_data/interaction.rs
+++ b/keriox_core/src/event/event_data/interaction.rs
@@ -1,5 +1,5 @@
 use super::super::sections::seal::*;
-use crate::database::redb::rkyv_adapter::said_wrapper::SaidValue;
+use crate::database::rkyv_adapter::said_wrapper::SaidValue;
 use crate::error::Error;
 use crate::state::{EventSemantics, IdentifierState};
 use said::SelfAddressingIdentifier;

--- a/keriox_core/src/event/event_data/rotation.rs
+++ b/keriox_core/src/event/event_data/rotation.rs
@@ -1,6 +1,6 @@
 use super::super::sections::{seal::*, KeyConfig, RotationWitnessConfig};
 use crate::{
-    database::redb::rkyv_adapter::said_wrapper::SaidValue,
+    database::rkyv_adapter::said_wrapper::SaidValue,
     error::Error,
     prefix::BasicPrefix,
     state::{EventSemantics, IdentifierState, LastEstablishmentData, WitnessConfig},

--- a/keriox_core/src/event/sections/key_config.rs
+++ b/keriox_core/src/event/sections/key_config.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use super::threshold::SignatureThreshold;
 use crate::{
-    database::redb::rkyv_adapter::said_wrapper::SaidValue,
+    database::rkyv_adapter::said_wrapper::SaidValue,
     prefix::{attached_signature::Index, BasicPrefix, IndexedSignature},
 };
 

--- a/keriox_core/src/event/sections/seal.rs
+++ b/keriox_core/src/event/sections/seal.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display};
 
-use crate::{database::redb::rkyv_adapter::said_wrapper::SaidValue, prefix::IdentifierPrefix};
+use crate::{database::rkyv_adapter::said_wrapper::SaidValue, prefix::IdentifierPrefix};
 use said::SelfAddressingIdentifier;
 use serde::{Deserialize, Serialize};
 use serde_hex::{Compact, SerHex};

--- a/keriox_core/src/event_message/msg.rs
+++ b/keriox_core/src/event_message/msg.rs
@@ -5,8 +5,8 @@ use said::{
 use serde::{Deserialize, Serialize};
 
 use super::{EventTypeTag, Typeable};
-use crate::database::redb::rkyv_adapter::said_wrapper::SaidValue;
-use crate::database::redb::rkyv_adapter::serialization_info_wrapper::SerializationInfoDef;
+use crate::database::rkyv_adapter::said_wrapper::SaidValue;
+use crate::database::rkyv_adapter::serialization_info_wrapper::SerializationInfoDef;
 use crate::error::Error;
 
 pub type KeriEvent<D> = TypedEvent<EventTypeTag, D>;

--- a/keriox_core/src/oobi_manager/mod.rs
+++ b/keriox_core/src/oobi_manager/mod.rs
@@ -1,42 +1,40 @@
-use std::{convert::TryFrom, sync::Arc};
-use crate::oobi::{Role, error::OobiError};
+use std::convert::TryFrom;
 
 use cesrox::parse_many;
 
 use crate::{
-    database::redb::{RedbDatabase, RedbError},
     error::Error,
     event_message::signed_event_message::{Message, Op},
+    oobi::{error::OobiError, Role},
     prefix::IdentifierPrefix,
     query::reply_event::{bada_logic, ReplyEvent, ReplyRoute, SignedReply},
 };
 
 pub mod storage;
 
-use self::storage::OobiStorage;
+use self::storage::OobiStorageBackend;
 
-pub struct OobiManager {
-    store: OobiStorage,
+#[cfg(feature = "storage-redb")]
+use self::storage::RedbOobiStorage;
+
+#[cfg(feature = "storage-redb")]
+pub struct OobiManager<S: OobiStorageBackend = RedbOobiStorage> {
+    store: S,
 }
 
-impl OobiManager {
-    pub fn new(events_db: Arc<RedbDatabase>) -> Self {
-        Self {
-            store: OobiStorage::new(events_db.db.clone()).unwrap(),
-        }
+#[cfg(not(feature = "storage-redb"))]
+pub struct OobiManager<S: OobiStorageBackend> {
+    store: S,
+}
+
+impl<S: OobiStorageBackend> OobiManager<S> {
+    pub fn with_storage(store: S) -> Self {
+        Self { store }
     }
 
-    pub fn new_from_db(db: Arc<redb::Database>) -> Self {
-        Self {
-            store: OobiStorage::new(db.clone()).unwrap(),
-        }
-    }
-
-    /// Checks oobi signer and bada logic. Assumes signatures already
-    /// verified.
+    /// Checks oobi signer and bada logic. Assumes signatures already verified.
     pub fn check_oobi_reply(&self, rpy: &SignedReply) -> Result<(), OobiError> {
         match rpy.reply.get_route() {
-            // check if signature was made by oobi creator
             ReplyRoute::LocScheme(lc) => {
                 if rpy.signature.get_signer().ok_or(Error::MissingSigner)? != lc.get_eid() {
                     return Err(OobiError::SignerMismatch);
@@ -45,7 +43,7 @@ impl OobiManager {
                 if let Some(old_rpy) = self
                     .store
                     .get_last_loc_scheme(&lc.eid, &lc.scheme)
-                    .map_err(|err| OobiError::Db(err.to_string()))?
+                    .map_err(|e| OobiError::Db(e.to_string()))?
                 {
                     bada_logic(rpy, &old_rpy)?;
                 };
@@ -58,7 +56,7 @@ impl OobiManager {
                 if let Some(old_rpy) = self
                     .store
                     .get_end_role(&er.cid, er.role)
-                    .map_err(|err| OobiError::Db(err.to_string()))?
+                    .map_err(|e| OobiError::Db(e.to_string()))?
                     .and_then(|rpys| rpys.last().cloned())
                 {
                     bada_logic(rpy, &old_rpy)?;
@@ -79,7 +77,9 @@ impl OobiManager {
                 match msg {
                     Message::Op(Op::Reply(oobi_rpy)) => {
                         self.check_oobi_reply(&oobi_rpy)?;
-                        self.store.save_oobi(&oobi_rpy)?;
+                        self.store
+                            .save_oobi(&oobi_rpy)
+                            .map_err(|e| OobiError::Db(e.to_string()))?;
                         Ok(())
                     }
                     _ => Err(OobiError::InvalidMessageType),
@@ -87,14 +87,18 @@ impl OobiManager {
             })?;
         Ok(())
     }
-    pub fn save_oobi(&self, signed_oobi: &SignedReply) -> Result<(), RedbError> {
-        self.store.save_oobi(signed_oobi)
+
+    pub fn save_oobi(&self, signed_oobi: &SignedReply) -> Result<(), OobiError> {
+        self.store
+            .save_oobi(signed_oobi)
+            .map_err(|e| OobiError::Db(e.to_string()))
     }
 
-    pub fn get_loc_scheme(&self, id: &IdentifierPrefix) -> Result<Vec<ReplyEvent>, RedbError> {
+    pub fn get_loc_scheme(&self, id: &IdentifierPrefix) -> Result<Vec<ReplyEvent>, OobiError> {
         Ok(self
             .store
-            .get_oobis_for_eid(id)?
+            .get_oobis_for_eid(id)
+            .map_err(|e| OobiError::Db(e.to_string()))?
             .into_iter()
             .map(|e| e.reply)
             .collect())
@@ -104,29 +108,50 @@ impl OobiManager {
         &self,
         id: &IdentifierPrefix,
         role: Role,
-    ) -> Result<Option<Vec<SignedReply>>, RedbError> {
-        self.store.get_end_role(id, role)
+    ) -> Result<Option<Vec<SignedReply>>, OobiError> {
+        self.store
+            .get_end_role(id, role)
+            .map_err(|e| OobiError::Db(e.to_string()))
     }
 
     /// Assumes that signatures were verified.
     pub fn process_oobi(&self, oobi_rpy: &SignedReply) -> Result<(), OobiError> {
-        println!("\nProcessing oobi");
         self.check_oobi_reply(oobi_rpy)?;
-        println!("Checked\n");
-        self.store.save_oobi(oobi_rpy)?;
+        self.store
+            .save_oobi(oobi_rpy)
+            .map_err(|e| OobiError::Db(e.to_string()))?;
         Ok(())
     }
 }
 
-impl From<RedbError> for OobiError {
-    fn from(err: RedbError) -> Self {
-        OobiError::Db(err.to_string())
+#[cfg(feature = "storage-redb")]
+impl OobiManager<RedbOobiStorage> {
+    /// Create a redb-backed OobiManager from a `RedbDatabase` wrapper.
+    pub fn new(events_db: std::sync::Arc<crate::database::redb::RedbDatabase>) -> Result<Self, OobiError> {
+        let store = RedbOobiStorage::new(events_db.db.clone())
+            .map_err(|e| OobiError::Db(e.to_string()))?;
+        Ok(Self { store })
+    }
+
+    /// Create a redb-backed OobiManager directly from a raw redb `Database`.
+    pub fn new_redb(db: std::sync::Arc<redb::Database>) -> Result<Self, OobiError> {
+        let store = RedbOobiStorage::new(db).map_err(|e| OobiError::Db(e.to_string()))?;
+        Ok(Self { store })
+    }
+}
+
+#[cfg(feature = "storage-postgres")]
+impl OobiManager<crate::database::postgres::oobi_storage::PostgresOobiStorage> {
+    /// Create a postgres-backed OobiManager from an existing `PgPool`.
+    pub fn new_postgres(pool: sqlx::PgPool) -> Self {
+        Self {
+            store: crate::database::postgres::oobi_storage::PostgresOobiStorage::new(pool),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-
     use std::sync::Arc;
 
     use cesrox::parse_many;
@@ -134,27 +159,28 @@ mod tests {
 
     use crate::{
         oobi::error::OobiError,
-        oobi_manager::OobiManager, prefix::IdentifierPrefix, query::reply_event::ReplyRoute,
+        oobi_manager::OobiManager,
+        prefix::IdentifierPrefix,
+        query::reply_event::ReplyRoute,
     };
 
     fn setup_oobi_manager() -> OobiManager {
         let tmp_path = NamedTempFile::new().unwrap();
         let redb = Arc::new(redb::Database::create(tmp_path.path()).unwrap());
-
-        OobiManager::new_from_db(redb)
+        OobiManager::new_redb(redb).unwrap()
     }
 
     #[test]
     fn test_obi_save() -> Result<(), OobiError> {
         let oobi_manager = setup_oobi_manager();
 
-        let body = r#"{"v":"KERI10JSON0000fa_","t":"rpy","d":"EJq4dQQdqg8aK7VyGnfSibxPyW8Zk2zO1qbVRD6flOvE","dt":"2022-02-28T17:23:20.336207+00:00","r":"/loc/scheme","a":{"eid":"BuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw","scheme":"http","url":"http://127.0.0.1:5643/"}}-VAi-CABBuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw0BAPJ5p_IpUFdmq8uupehsL8DzxWDeaU_SjeiwfmRZ6i9pqddraItmCOAysdXdTEQZ1hEM60iDEWvK16g68TrcAw{"v":"KERI10JSON0000f8_","t":"rpy","d":"ExSR01j5noF2LnGcGFUbLnq-U8JuYBr9WWEMt8d2fb1Y","dt":"2022-02-28T17:23:20.337272+00:00","r":"/loc/scheme","a":{"eid":"BuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw","scheme":"tcp","url":"tcp://127.0.0.1:5633/"}}-VAi-CABBuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw0BZtIhK6Nh6Zk1zPmkJYiFVz0RimQRiubshmSmqAzxzhT4KpGMAH7sbNlFP-0-lKjTawTReKv4L7N3TR7jxXaEBg"#; //{"v":"KERI10JSON000116_","t":"rpy","d":"EcZ1I4nKy6gIkWxjq1LmIivoPGv32lvlSuMVsWnOPwSc","dt":"2022-02-28T17:23:20.338355+00:00","r":"/end/role/add","a":{"cid":"BuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw","role":"controller","eid":"BuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw"}}-VAi-CABBuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw0B9ccIiMxdwurRjGvUUUdXsxhseo58onhE4bJddKuyPaSpBHXdRKKuiFE0SmLAogMQGJ0iN6f1V_2E_MVfMc3sAA"#;
+        let body = r#"{"v":"KERI10JSON0000fa_","t":"rpy","d":"EJq4dQQdqg8aK7VyGnfSibxPyW8Zk2zO1qbVRD6flOvE","dt":"2022-02-28T17:23:20.336207+00:00","r":"/loc/scheme","a":{"eid":"BuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw","scheme":"http","url":"http://127.0.0.1:5643/"}}-VAi-CABBuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw0BAPJ5p_IpUFdmq8uupehsL8DzxWDeaU_SjeiwfmRZ6i9pqddraItmCOAysdXdTEQZ1hEM60iDEWvK16g68TrcAw{"v":"KERI10JSON0000f8_","t":"rpy","d":"ExSR01j5noF2LnGcGFUbLnq-U8JuYBr9WWEMt8d2fb1Y","dt":"2022-02-28T17:23:20.337272+00:00","r":"/loc/scheme","a":{"eid":"BuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw","scheme":"tcp","url":"tcp://127.0.0.1:5633/"}}-VAi-CABBuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw0BZtIhK6Nh6Zk1zPmkJYiFVz0RimQRiubshmSmqAzxzhT4KpGMAH7sbNlFP-0-lKjTawTReKv4L7N3TR7jxXaEBg"#;
         let stream = parse_many(body.as_bytes());
         assert_eq!(stream.unwrap().1.len(), 2);
 
         oobi_manager.parse_and_save(body)?;
 
-        let res = oobi_manager.store.get_oobis_for_eid(
+        let res = oobi_manager.get_loc_scheme(
             &"BuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw"
                 .parse::<IdentifierPrefix>()
                 .unwrap(),
@@ -162,12 +188,12 @@ mod tests {
         assert!(!res.is_empty());
 
         assert_eq!(
-        res.iter().map(|oobi| oobi.reply.get_route()).collect::<Vec<_>>(),
-        vec![
-            ReplyRoute::LocScheme(serde_json::from_str(r#"{"eid":"BuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw","scheme":"http","url":"http://127.0.0.1:5643/"}"#).unwrap()),
-            ReplyRoute::LocScheme(serde_json::from_str(r#"{"eid":"BuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw","scheme":"tcp","url":"tcp://127.0.0.1:5633/"}"#).unwrap()),
-        ]
-    );
+            res.iter().map(|oobi| oobi.get_route()).collect::<Vec<_>>(),
+            vec![
+                ReplyRoute::LocScheme(serde_json::from_str(r#"{"eid":"BuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw","scheme":"http","url":"http://127.0.0.1:5643/"}"#).unwrap()),
+                ReplyRoute::LocScheme(serde_json::from_str(r#"{"eid":"BuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw","scheme":"tcp","url":"tcp://127.0.0.1:5633/"}"#).unwrap()),
+            ]
+        );
 
         Ok(())
     }
@@ -176,57 +202,50 @@ mod tests {
     pub fn test_oobi_update() -> Result<(), OobiError> {
         let oobi_manager = setup_oobi_manager();
 
-        let body = r#"{"v":"KERI10JSON0000fa_","t":"rpy","d":"Elxbk-5h8a2PhoserezofHRXEDgAEwhrW0wvhXqyupmY","dt":"2022-04-08T15:00:29.163849+00:00","r":"/loc/scheme","a":{"eid":"Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c","scheme":"http","url":"http://127.0.0.1:5644/"}}-VAi-CABBgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c0BezpFQMVxodb7WMUBL4aLeQW1CUTUYbcFNPGohh02cKl7kSajyRZAentI-MkconvyI8-QfaO1in5mexYF-1ZPBg{"v":"KERI10JSON0000f8_","t":"rpy","d":"EfJP2Mkp_2UZJoWoNCWZHMgU7uWMIkzih19Nvit36Cho","dt":"2022-04-08T15:00:29.165103+00:00","r":"/loc/scheme","a":{"eid":"Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c","scheme":"tcp","url":"tcp://127.0.0.1:5634/"}}-VAi-CABBgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c0BFcwrcL7Hc8HYLSPvzMGAAEn5QyY76QWY1l2RotQqsX01HgDh4UZYU5GpiVY2A-AbsRIsUpfIKnQi7r4dc0o0DA"#; //{"v":"KERI10JSON000116_","t":"rpy","d":"EXhq-JsyKmr7PJq7luQ0Psd1linhiL6yI4iiDStKPYSw","dt":"2022-04-08T15:00:29.166115+00:00","r":"/end/role/add","a":{"cid":"Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c","role":"controller","eid":"Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c"}}-VAi-CABBgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c0BJwAp49PBodHj42HlBoStigxsgGEWmdaMOyaY6_q1msdS5pi66SWFCNuLqPWX6p1YWXDmq97MgKZmTRJ3g7mPCg"#;
-        let body2 = r#"{"v":"KERI10JSON0000fa_","t":"rpy","d":"EhmRb98IbAp7xqttLe-knTcT0pg5xbkFdU-D8FMi2NTE","dt":"2022-04-08T15:02:55.382713+00:00","r":"/loc/scheme","a":{"eid":"Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c","scheme":"http","url":"http://127.0.0.1:5644/"}}-VAi-CABBgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c0BQ2LHGCoTDzGTU4qnAKvnZocjUEwWfpILfngi5Ej3z_7SGJ5q4ciQSZ2uyBONGNqDeOsyrI4vV5LvrQUxg0vLCg{"v":"KERI10JSON0000f8_","t":"rpy","d":"EQqXdsemACUttgKUOiCYTs9JyXIjbio1itQdA2TeKF0I","dt":"2022-04-08T15:02:55.384117+00:00","r":"/loc/scheme","a":{"eid":"Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c","scheme":"tcp","url":"tcp://127.0.0.1:5634/"}}-VAi-CABBgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c0BD1uIyxgm1MFqhkwlbwarxOdNghWIrs_ClHLrHVj-qpGpS2cM1T1Y8E3GUsfvpsvkHNWUFCBZmaQHoSI4WE2cAw"#; //{"v":"KERI10JSON000116_","t":"rpy","d":"E2P4sXDFiU5MnLCk7pMm7IHWOu9UNrqLqnKZJWjdcvuo","dt":"2022-04-08T15:02:55.385191+00:00","r":"/end/role/add","a":{"cid":"Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c","role":"controller","eid":"Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c"}}-VAi-CABBgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c0B66IhoBb_nIQjY6wlNHwZHicm2Yf4Ioxbm5cnfSvPLQHFjhE7ROXTDlNfZIjyXMmmboHRtpLrCfHO5kz90PF6CA"#;
+        let body = r#"{"v":"KERI10JSON0000fa_","t":"rpy","d":"Elxbk-5h8a2PhoserezofHRXEDgAEwhrW0wvhXqyupmY","dt":"2022-04-08T15:00:29.163849+00:00","r":"/loc/scheme","a":{"eid":"Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c","scheme":"http","url":"http://127.0.0.1:5644/"}}-VAi-CABBgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c0BezpFQMVxodb7WMUBL4aLeQW1CUTUYbcFNPGohh02cKl7kSajyRZAentI-MkconvyI8-QfaO1in5mexYF-1ZPBg{"v":"KERI10JSON0000f8_","t":"rpy","d":"EfJP2Mkp_2UZJoWoNCWZHMgU7uWMIkzih19Nvit36Cho","dt":"2022-04-08T15:00:29.165103+00:00","r":"/loc/scheme","a":{"eid":"Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c","scheme":"tcp","url":"tcp://127.0.0.1:5634/"}}-VAi-CABBgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c0BFcwrcL7Hc8HYLSPvzMGAAEn5QyY76QWY1l2RotQqsX01HgDh4UZYU5GpiVY2A-AbsRIsUpfIKnQi7r4dc0o0DA"#;
+        let body2 = r#"{"v":"KERI10JSON0000fa_","t":"rpy","d":"EhmRb98IbAp7xqttLe-knTcT0pg5xbkFdU-D8FMi2NTE","dt":"2022-04-08T15:02:55.382713+00:00","r":"/loc/scheme","a":{"eid":"Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c","scheme":"http","url":"http://127.0.0.1:5644/"}}-VAi-CABBgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c0BQ2LHGCoTDzGTU4qnAKvnZocjUEwWfpILfngi5Ej3z_7SGJ5q4ciQSZ2uyBONGNqDeOsyrI4vV5LvrQUxg0vLCg{"v":"KERI10JSON0000f8_","t":"rpy","d":"EQqXdsemACUttgKUOiCYTs9JyXIjbio1itQdA2TeKF0I","dt":"2022-04-08T15:02:55.384117+00:00","r":"/loc/scheme","a":{"eid":"Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c","scheme":"tcp","url":"tcp://127.0.0.1:5634/"}}-VAi-CABBgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c0BD1uIyxgm1MFqhkwlbwarxOdNghWIrs_ClHLrHVj-qpGpS2cM1T1Y8E3GUsfvpsvkHNWUFCBZmaQHoSI4WE2cAw"#;
 
         oobi_manager.parse_and_save(body)?;
 
-        let res = oobi_manager.store.get_oobis_for_eid(
+        let res = oobi_manager.get_loc_scheme(
             &"Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c"
                 .parse::<IdentifierPrefix>()
                 .unwrap(),
         )?;
         assert!(!res.is_empty());
-        // Save timestamps of last accepted oobis.
         let timestamps = res
-            .clone()
             .iter()
-            .map(|reply| reply.reply.get_timestamp())
+            .map(|reply| reply.get_timestamp())
             .collect::<Vec<_>>();
 
         assert_eq!(
-        res.iter().map(|oobi| oobi.reply.get_route()).collect::<Vec<_>>(),
-        vec![
-            ReplyRoute::LocScheme(serde_json::from_str(r#"{"eid":"Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c","scheme":"http","url":"http://127.0.0.1:5644/"}"#).unwrap()),
-            ReplyRoute::LocScheme(serde_json::from_str(r#"{"eid":"Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c","scheme":"tcp","url":"tcp://127.0.0.1:5634/"}"#).unwrap())
-        ]
-    );
+            res.iter().map(|oobi| oobi.get_route()).collect::<Vec<_>>(),
+            vec![
+                ReplyRoute::LocScheme(serde_json::from_str(r#"{"eid":"Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c","scheme":"http","url":"http://127.0.0.1:5644/"}"#).unwrap()),
+                ReplyRoute::LocScheme(serde_json::from_str(r#"{"eid":"Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c","scheme":"tcp","url":"tcp://127.0.0.1:5634/"}"#).unwrap())
+            ]
+        );
 
-        // process the same oobis but with new timestamp
         oobi_manager.parse_and_save(body2)?;
 
-        let res = oobi_manager.store.get_oobis_for_eid(
+        let res = oobi_manager.get_loc_scheme(
             &"Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c"
                 .parse::<IdentifierPrefix>()
                 .unwrap(),
         )?;
         assert!(!res.is_empty());
-        // Save timestamps of last accepted oobis.
         let timestamps2 = res
-            .clone()
             .iter()
-            .map(|reply| reply.reply.get_timestamp())
+            .map(|reply| reply.get_timestamp())
             .collect::<Vec<_>>();
 
-        // The same oobis should be in database.
         assert_eq!(
-        res.iter().map(|oobi| oobi.reply.get_route()).collect::<Vec<_>>(),
-        vec![
-            ReplyRoute::LocScheme(serde_json::from_str(r#"{"eid":"Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c","scheme":"http","url":"http://127.0.0.1:5644/"}"#).unwrap()),
-            ReplyRoute::LocScheme(serde_json::from_str(r#"{"eid":"Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c","scheme":"tcp","url":"tcp://127.0.0.1:5634/"}"#).unwrap())
-        ]
-    );
-        // But timestamps should be updated.
+            res.iter().map(|oobi| oobi.get_route()).collect::<Vec<_>>(),
+            vec![
+                ReplyRoute::LocScheme(serde_json::from_str(r#"{"eid":"Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c","scheme":"http","url":"http://127.0.0.1:5644/"}"#).unwrap()),
+                ReplyRoute::LocScheme(serde_json::from_str(r#"{"eid":"Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c","scheme":"tcp","url":"tcp://127.0.0.1:5634/"}"#).unwrap())
+            ]
+        );
         assert_ne!(timestamps, timestamps2);
 
         Ok(())

--- a/keriox_core/src/oobi_manager/mod.rs
+++ b/keriox_core/src/oobi_manager/mod.rs
@@ -14,18 +14,16 @@ pub mod storage;
 
 use self::storage::OobiStorageBackend;
 
-#[cfg(feature = "storage-redb")]
-use self::storage::RedbOobiStorage;
-
-#[cfg(feature = "storage-redb")]
-pub struct OobiManager<S: OobiStorageBackend = RedbOobiStorage> {
-    store: S,
-}
-
-#[cfg(not(feature = "storage-redb"))]
 pub struct OobiManager<S: OobiStorageBackend> {
     store: S,
 }
+
+#[cfg(feature = "storage-redb")]
+pub type RedbOobiManager = OobiManager<self::storage::RedbOobiStorage>;
+
+#[cfg(feature = "storage-postgres")]
+pub type PostgresOobiManager =
+    OobiManager<crate::database::postgres::oobi_storage::PostgresOobiStorage>;
 
 impl<S: OobiStorageBackend> OobiManager<S> {
     pub fn with_storage(store: S) -> Self {
@@ -125,17 +123,17 @@ impl<S: OobiStorageBackend> OobiManager<S> {
 }
 
 #[cfg(feature = "storage-redb")]
-impl OobiManager<RedbOobiStorage> {
+impl OobiManager<self::storage::RedbOobiStorage> {
     /// Create a redb-backed OobiManager from a `RedbDatabase` wrapper.
     pub fn new(events_db: std::sync::Arc<crate::database::redb::RedbDatabase>) -> Result<Self, OobiError> {
-        let store = RedbOobiStorage::new(events_db.db.clone())
+        let store = self::storage::RedbOobiStorage::new(events_db.db.clone())
             .map_err(|e| OobiError::Db(e.to_string()))?;
         Ok(Self { store })
     }
 
     /// Create a redb-backed OobiManager directly from a raw redb `Database`.
     pub fn new_redb(db: std::sync::Arc<redb::Database>) -> Result<Self, OobiError> {
-        let store = RedbOobiStorage::new(db).map_err(|e| OobiError::Db(e.to_string()))?;
+        let store = self::storage::RedbOobiStorage::new(db).map_err(|e| OobiError::Db(e.to_string()))?;
         Ok(Self { store })
     }
 }
@@ -159,12 +157,12 @@ mod tests {
 
     use crate::{
         oobi::error::OobiError,
-        oobi_manager::OobiManager,
+        oobi_manager::{OobiManager, RedbOobiManager},
         prefix::IdentifierPrefix,
         query::reply_event::ReplyRoute,
     };
 
-    fn setup_oobi_manager() -> OobiManager {
+    fn setup_oobi_manager() -> RedbOobiManager {
         let tmp_path = NamedTempFile::new().unwrap();
         let redb = Arc::new(redb::Database::create(tmp_path.path()).unwrap());
         OobiManager::new_redb(redb).unwrap()

--- a/keriox_core/src/oobi_manager/storage.rs
+++ b/keriox_core/src/oobi_manager/storage.rs
@@ -1,150 +1,208 @@
-use std::sync::Arc;
-
-use redb::{MultimapTableDefinition, TableDefinition};
+use crate::{
+    prefix::IdentifierPrefix,
+    query::reply_event::SignedReply,
+};
 
 use super::Role;
 use crate::oobi::Scheme;
-use crate::{
-    database::redb::RedbError,
-    prefix::IdentifierPrefix,
-    query::reply_event::{ReplyRoute, SignedReply},
-};
 
-/// Location OOBIs store (eid, scheme) -> Signed oobi
-const LOCATION: TableDefinition<(&str, &str), &[u8]> = TableDefinition::new("location");
+pub trait OobiStorageBackend: Send + Sync {
+    type Error: std::error::Error + Send + Sync + 'static;
 
-/// End role OOBIs store (cid, role) -> Signed oobi
-const END_ROLE: MultimapTableDefinition<(&[u8], &[u8]), &[u8]> =
-    MultimapTableDefinition::new("end_role");
+    fn get_oobis_for_eid(&self, id: &IdentifierPrefix) -> Result<Vec<SignedReply>, Self::Error>;
 
-pub struct OobiStorage {
-    db: Arc<redb::Database>,
-}
-impl OobiStorage {
-    pub fn new(db: Arc<redb::Database>) -> Result<Self, RedbError> {
-        // Create tables
-        let write_txn = db.begin_write()?;
-        {
-            write_txn.open_table(LOCATION)?;
-            write_txn.open_multimap_table(END_ROLE)?;
-        }
-        write_txn.commit()?;
-        Ok(Self { db })
-    }
-
-    pub fn get_oobis_for_eid(&self, id: &IdentifierPrefix) -> Result<Vec<SignedReply>, RedbError> {
-        let str_id = id.to_string();
-        let start = (str_id.as_str(), "");
-
-        // End of the range: ("apple\u{FFFD}", "")
-        // Adding a character greater than any normal Unicode character ensures the end is exclusive
-        let mut end_prefix = str_id.to_owned();
-        end_prefix.push('\u{FFFD}'); // or use '\u{10FFFF}' for max valid Unicode scalar
-        let end = (end_prefix.as_str(), "");
-
-        let signed_oobis = {
-            let read_txn = self.db.begin_read().unwrap();
-            let table = read_txn.open_table(LOCATION).unwrap();
-            table.range(start..end)
-        }
-        .unwrap();
-
-        let out = signed_oobis
-            .filter_map(|entry| {
-                let (_, value) = entry.unwrap();
-                serde_cbor::from_slice::<SignedReply>(value.value()).ok()
-            })
-            .collect();
-        Ok(out)
-    }
-
-    pub fn get_last_loc_scheme(
+    fn get_last_loc_scheme(
         &self,
         eid: &IdentifierPrefix,
         scheme: &Scheme,
-    ) -> Result<Option<SignedReply>, RedbError> {
-        let read_txn = self.db.begin_read().unwrap();
-        let table = read_txn.open_table(LOCATION).unwrap();
-        let el = table
-            .get((
-                eid.to_string().as_str(),
-                serde_json::to_string(scheme).unwrap().as_str(),
-            ))
-            .unwrap();
+    ) -> Result<Option<SignedReply>, Self::Error>;
 
-        let out = el.and_then(|entry| {
-            // let (_, value) = entry;
-            serde_cbor::from_slice::<SignedReply>(entry.value()).ok()
-        });
-        Ok(out)
-    }
-
-    pub fn get_end_role(
+    fn get_end_role(
         &self,
         cid: &IdentifierPrefix,
         role: Role,
-    ) -> Result<Option<Vec<SignedReply>>, RedbError> {
-        let read_txn = self.db.begin_read().unwrap();
-        let table = read_txn.open_multimap_table(END_ROLE).unwrap();
-        let entry = table
-            .get((
-                cid.to_string().as_bytes(),
-                serde_json::to_vec(&role).unwrap().as_slice(),
-            ))
-            .unwrap();
-        let out: Option<Vec<SignedReply>> = entry
-            .map(|entry| {
-                let value = entry.unwrap();
-                serde_cbor::from_slice::<SignedReply>(value.value()).ok()
-            })
-            .collect();
-        Ok(out)
+    ) -> Result<Option<Vec<SignedReply>>, Self::Error>;
+
+    fn save_oobi(&self, signed_reply: &SignedReply) -> Result<(), Self::Error>;
+}
+
+#[cfg(feature = "storage-redb")]
+mod redb_backend {
+    use std::sync::Arc;
+
+    use redb::{MultimapTableDefinition, TableDefinition};
+
+    use crate::{
+        database::redb::RedbError,
+        oobi::Scheme,
+        prefix::IdentifierPrefix,
+        query::reply_event::{ReplyRoute, SignedReply},
+    };
+
+    use super::{super::Role, OobiStorageBackend};
+
+    /// Location OOBIs store (eid, scheme) -> Signed oobi
+    const LOCATION: TableDefinition<(&str, &str), &[u8]> = TableDefinition::new("location");
+
+    /// End role OOBIs store (cid, role) -> Signed oobi
+    const END_ROLE: MultimapTableDefinition<(&[u8], &[u8]), &[u8]> =
+        MultimapTableDefinition::new("end_role");
+
+    pub struct RedbOobiStorage {
+        pub(super) db: Arc<redb::Database>,
     }
 
-    pub fn save_oobi(&self, signed_reply: &SignedReply) -> Result<(), RedbError> {
-        println!(
-            "\n\nSaving oobi for route: {:?}\n",
-            signed_reply.reply.get_route()
-        );
-        match signed_reply.reply.get_route() {
-            ReplyRoute::Ksn(_, _) => todo!(),
-            ReplyRoute::LocScheme(loc_scheme) => {
-                let (cid, scheme) = (
-                    loc_scheme.get_eid().to_string(),
-                    serde_json::to_string(&loc_scheme.scheme).unwrap(),
-                );
-
-                let write_txn = self.db.begin_write().unwrap();
-                {
-                    let mut table = (&write_txn).open_table(LOCATION).unwrap();
-                    table
-                        .insert(
-                            (cid.as_str(), scheme.as_str()),
-                            serde_cbor::to_vec(signed_reply).unwrap().as_slice(),
-                        )
-                        .unwrap();
-                }
-                write_txn.commit().unwrap();
+    impl RedbOobiStorage {
+        pub fn new(db: Arc<redb::Database>) -> Result<Self, RedbError> {
+            let write_txn = db.begin_write()?;
+            {
+                write_txn.open_table(LOCATION)?;
+                write_txn.open_multimap_table(END_ROLE)?;
             }
-            ReplyRoute::EndRoleAdd(end_role) | ReplyRoute::EndRoleCut(end_role) => {
-                let (eid, role) = (
-                    end_role.cid.to_string(),
-                    serde_json::to_vec(&end_role.role).unwrap(),
-                );
-
-                let write_txn = self.db.begin_write().unwrap();
-                {
-                    let mut table = (&write_txn).open_multimap_table(END_ROLE).unwrap();
-                    table
-                        .insert(
-                            (eid.as_bytes(), role.as_slice()),
-                            serde_cbor::to_vec(signed_reply).unwrap().as_slice(),
-                        )
-                        .unwrap();
-                }
-                write_txn.commit().unwrap();
-            }
+            write_txn.commit()?;
+            Ok(Self { db })
         }
-        Ok(())
+    }
+
+    impl OobiStorageBackend for RedbOobiStorage {
+        type Error = RedbError;
+
+        fn get_oobis_for_eid(
+            &self,
+            id: &IdentifierPrefix,
+        ) -> Result<Vec<SignedReply>, Self::Error> {
+            let str_id = id.to_string();
+            let start = (str_id.as_str(), "");
+
+            let mut end_prefix = str_id.to_owned();
+            end_prefix.push('\u{FFFD}');
+            let end = (end_prefix.as_str(), "");
+
+            let signed_oobis = {
+                let read_txn = self.db.begin_read().unwrap();
+                let table = read_txn.open_table(LOCATION).unwrap();
+                table.range(start..end)
+            }
+            .unwrap();
+
+            let out = signed_oobis
+                .filter_map(|entry| {
+                    let (_, value) = entry.unwrap();
+                    serde_cbor::from_slice::<SignedReply>(value.value()).ok()
+                })
+                .collect();
+            Ok(out)
+        }
+
+        fn get_last_loc_scheme(
+            &self,
+            eid: &IdentifierPrefix,
+            scheme: &Scheme,
+        ) -> Result<Option<SignedReply>, Self::Error> {
+            let read_txn = self.db.begin_read().unwrap();
+            let table = read_txn.open_table(LOCATION).unwrap();
+            let el = table
+                .get((
+                    eid.to_string().as_str(),
+                    serde_json::to_string(scheme).unwrap().as_str(),
+                ))
+                .unwrap();
+
+            let out =
+                el.and_then(|entry| serde_cbor::from_slice::<SignedReply>(entry.value()).ok());
+            Ok(out)
+        }
+
+        fn get_end_role(
+            &self,
+            cid: &IdentifierPrefix,
+            role: Role,
+        ) -> Result<Option<Vec<SignedReply>>, Self::Error> {
+            let read_txn = self.db.begin_read().unwrap();
+            let table = read_txn.open_multimap_table(END_ROLE).unwrap();
+            let entries: Vec<SignedReply> = table
+                .get((
+                    cid.to_string().as_bytes(),
+                    serde_json::to_vec(&role).unwrap().as_slice(),
+                ))
+                .unwrap()
+                .filter_map(|e| {
+                    let value = e.unwrap();
+                    serde_cbor::from_slice::<SignedReply>(value.value()).ok()
+                })
+                .collect();
+            Ok(if entries.is_empty() {
+                None
+            } else {
+                Some(entries)
+            })
+        }
+
+        fn save_oobi(&self, signed_reply: &SignedReply) -> Result<(), Self::Error> {
+            match signed_reply.reply.get_route() {
+                ReplyRoute::Ksn(_, _) => todo!(),
+                ReplyRoute::LocScheme(loc_scheme) => {
+                    let (cid, scheme) = (
+                        loc_scheme.get_eid().to_string(),
+                        serde_json::to_string(&loc_scheme.scheme).unwrap(),
+                    );
+
+                    let write_txn = self.db.begin_write().unwrap();
+                    {
+                        let mut table = (&write_txn).open_table(LOCATION).unwrap();
+                        table
+                            .insert(
+                                (cid.as_str(), scheme.as_str()),
+                                serde_cbor::to_vec(signed_reply).unwrap().as_slice(),
+                            )
+                            .unwrap();
+                    }
+                    write_txn.commit().unwrap();
+                }
+                ReplyRoute::EndRoleAdd(end_role) => {
+                    let (eid, role) = (
+                        end_role.cid.to_string(),
+                        serde_json::to_vec(&end_role.role).unwrap(),
+                    );
+
+                    let write_txn = self.db.begin_write().unwrap();
+                    {
+                        let mut table = (&write_txn).open_multimap_table(END_ROLE).unwrap();
+                        table
+                            .insert(
+                                (eid.as_bytes(), role.as_slice()),
+                                serde_cbor::to_vec(signed_reply).unwrap().as_slice(),
+                            )
+                            .unwrap();
+                    }
+                    write_txn.commit().unwrap();
+                }
+                ReplyRoute::EndRoleCut(end_role) => {
+                    // TODO: EndRoleCut should remove the role from storage, not insert.
+                    // Currently mirrors redb's behaviour (inserting the Cut event) pending
+                    // a proper removal implementation.
+                    let (eid, role) = (
+                        end_role.cid.to_string(),
+                        serde_json::to_vec(&end_role.role).unwrap(),
+                    );
+
+                    let write_txn = self.db.begin_write().unwrap();
+                    {
+                        let mut table = (&write_txn).open_multimap_table(END_ROLE).unwrap();
+                        table
+                            .insert(
+                                (eid.as_bytes(), role.as_slice()),
+                                serde_cbor::to_vec(signed_reply).unwrap().as_slice(),
+                            )
+                            .unwrap();
+                    }
+                    write_txn.commit().unwrap();
+                }
+            }
+            Ok(())
+        }
     }
 }
+
+#[cfg(feature = "storage-redb")]
+pub use redb_backend::RedbOobiStorage;

--- a/keriox_core/src/prefix/mod.rs
+++ b/keriox_core/src/prefix/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    database::redb::rkyv_adapter::said_wrapper::SaidValue,
+    database::rkyv_adapter::said_wrapper::SaidValue,
     event::sections::key_config::SignatureError,
 };
 

--- a/keriox_core/src/processor/escrow/reply_escrow.rs
+++ b/keriox_core/src/processor/escrow/reply_escrow.rs
@@ -2,15 +2,14 @@ use std::sync::Arc;
 
 use said::SelfAddressingIdentifier;
 
+#[cfg(feature = "storage-redb")]
+use crate::database::redb::{
+    escrow_database::SnKeyDatabase,
+    ksn_log::{AcceptedKsn, KsnLogDatabase},
+    RedbDatabase, RedbError,
+};
 use crate::{
-    database::{
-        redb::{
-            escrow_database::SnKeyDatabase,
-            ksn_log::{AcceptedKsn, KsnLogDatabase},
-            RedbDatabase, RedbError,
-        },
-        EventDatabase, SequencedEventDatabase,
-    },
+    database::{EventDatabase, SequencedEventDatabase},
     error::Error,
     prefix::IdentifierPrefix,
     processor::{
@@ -20,6 +19,7 @@ use crate::{
     query::reply_event::{ReplyEvent, ReplyRoute, SignedReply},
 };
 
+#[cfg(feature = "storage-redb")]
 #[derive(Clone)]
 pub struct ReplyEscrow<D: EventDatabase> {
     events_db: Arc<D>,
@@ -27,6 +27,7 @@ pub struct ReplyEscrow<D: EventDatabase> {
     escrowed_reply: Arc<SnKeyReplyEscrow>,
 }
 
+#[cfg(feature = "storage-redb")]
 impl ReplyEscrow<RedbDatabase> {
     pub fn new(events_db: Arc<RedbDatabase>) -> Self {
         let acc = Arc::new(AcceptedKsn::new(events_db.db.clone()).unwrap());
@@ -41,6 +42,7 @@ impl ReplyEscrow<RedbDatabase> {
         }
     }
 }
+#[cfg(feature = "storage-redb")]
 impl Notifier for ReplyEscrow<RedbDatabase> {
     fn notify(&self, notification: &Notification, bus: &NotificationBus) -> Result<(), Error> {
         match notification {
@@ -63,6 +65,7 @@ impl Notifier for ReplyEscrow<RedbDatabase> {
     }
 }
 
+#[cfg(feature = "storage-redb")]
 impl ReplyEscrow<RedbDatabase> {
     pub fn process_reply_escrow(
         &self,
@@ -100,11 +103,13 @@ impl ReplyEscrow<RedbDatabase> {
     }
 }
 
+#[cfg(feature = "storage-redb")]
 pub struct SnKeyReplyEscrow {
     escrow: Arc<SnKeyDatabase>,
     log: Arc<KsnLogDatabase>,
 }
 
+#[cfg(feature = "storage-redb")]
 impl SnKeyReplyEscrow {
     pub(crate) fn new(escrow: Arc<SnKeyDatabase>, log: Arc<KsnLogDatabase>) -> Self {
         Self { escrow, log }

--- a/keriox_core/src/processor/validator.rs
+++ b/keriox_core/src/processor/validator.rs
@@ -60,7 +60,7 @@ pub struct EventValidator<D: EventDatabase> {
     event_storage: EventStorage<D>,
 }
 
-impl<D: EventDatabase + std::any::Any> EventValidator<D> {
+impl<D: EventDatabase> EventValidator<D> {
     pub fn new(event_database: Arc<D>) -> Self {
         Self {
             event_storage: EventStorage::new(event_database),

--- a/keriox_core/src/state/mod.rs
+++ b/keriox_core/src/state/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use crate::{
-    database::redb::rkyv_adapter::said_wrapper::SaidValue,
+    database::rkyv_adapter::said_wrapper::SaidValue,
     error::Error,
     event::{
         event_data::EventData,

--- a/keriox_core/tests/test_oobi_manager.rs
+++ b/keriox_core/tests/test_oobi_manager.rs
@@ -20,7 +20,7 @@ mod test_oobi_manager {
         let (processor, storage, oobi_manager) = (
             BasicProcessor::new(events_db.clone(), None),
             EventStorage::new(events_db.clone()),
-            OobiManager::new(events_db.clone()),
+            OobiManager::new(events_db.clone()).unwrap(),
         );
         let events = parse_event_stream(oobi_rpy.as_bytes()).unwrap();
         for event in events {

--- a/support/teliox/Cargo.toml
+++ b/support/teliox/Cargo.toml
@@ -9,6 +9,10 @@ repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["storage-redb"]
+storage-redb = ["keri-core/storage-redb", "redb"]
+
 [dependencies]
 keri-core = {path = "../../keriox_core", version= "0.17.9", features = ["query"]}
 said = { version = "0.4.0" }
@@ -21,7 +25,7 @@ serde-hex = "0.1"
 chrono = { version = "0.4.18", features = ["serde"] }
 arrayref = "0.3.6"
 serde_cbor = "0.11.1"
-redb = "2.6.0"
+redb = { version = "2.6.0", optional = true }
 
 
 [dev-dependencies]

--- a/support/teliox/src/database/mod.rs
+++ b/support/teliox/src/database/mod.rs
@@ -1,13 +1,12 @@
 use crate::{error::Error, event::verifiable_event::VerifiableEvent};
-use ::redb::Database;
-use keri_core::{database::redb::WriteTxnMode, prefix::IdentifierPrefix};
+use keri_core::prefix::IdentifierPrefix;
+#[cfg(feature = "storage-redb")]
 use said::SelfAddressingIdentifier;
-use std::{
-    fs::{create_dir_all, exists},
-    path::Path,
-    sync::Arc,
-};
+use std::path::Path;
+
+#[cfg(feature = "storage-redb")]
 pub(crate) mod digest_key_database;
+#[cfg(feature = "storage-redb")]
 pub mod redb;
 
 pub trait TelEventDatabase {
@@ -28,15 +27,23 @@ pub trait TelEventDatabase {
     ) -> Option<impl DoubleEndedIterator<Item = VerifiableEvent>>;
 }
 
+#[cfg(feature = "storage-redb")]
 pub trait TelLogDatabase {
-    fn log_event(&self, event: &VerifiableEvent, transaction: &WriteTxnMode) -> Result<(), Error>;
+    fn log_event(
+        &self,
+        event: &VerifiableEvent,
+        transaction: &keri_core::database::redb::WriteTxnMode,
+    ) -> Result<(), Error>;
     fn get(&self, digest: &SelfAddressingIdentifier) -> Result<Option<VerifiableEvent>, Error>;
 }
 
-pub struct EscrowDatabase(pub(crate) Arc<Database>);
+#[cfg(feature = "storage-redb")]
+pub struct EscrowDatabase(pub(crate) std::sync::Arc<::redb::Database>);
 
+#[cfg(feature = "storage-redb")]
 impl EscrowDatabase {
     pub fn new(file_path: &Path) -> Result<Self, Error> {
+        use std::fs::{create_dir_all, exists};
         // Create file if not exists
         if !std::fs::exists(file_path).map_err(|e| Error::EscrowDatabaseError(e.to_string()))? {
             if let Some(parent) = file_path.parent() {
@@ -46,8 +53,8 @@ impl EscrowDatabase {
                 }
             }
         }
-        let db =
-            Database::create(file_path).map_err(|e| Error::EscrowDatabaseError(e.to_string()))?;
-        Ok(Self(Arc::new(db)))
+        let db = ::redb::Database::create(file_path)
+            .map_err(|e| Error::EscrowDatabaseError(e.to_string()))?;
+        Ok(Self(std::sync::Arc::new(db)))
     }
 }

--- a/support/teliox/src/error.rs
+++ b/support/teliox/src/error.rs
@@ -44,24 +44,28 @@ pub enum Error {
     RwLockingError,
 }
 
+#[cfg(feature = "storage-redb")]
 impl From<redb::TransactionError> for Error {
     fn from(_: redb::TransactionError) -> Self {
         Error::RedbError
     }
 }
 
+#[cfg(feature = "storage-redb")]
 impl From<redb::TableError> for Error {
     fn from(_: redb::TableError) -> Self {
         Error::RedbError
     }
 }
 
+#[cfg(feature = "storage-redb")]
 impl From<redb::CommitError> for Error {
     fn from(_: redb::CommitError) -> Self {
         Error::RedbError
     }
 }
 
+#[cfg(feature = "storage-redb")]
 impl From<redb::StorageError> for Error {
     fn from(_: redb::StorageError) -> Self {
         Error::RedbError

--- a/support/teliox/src/processor/escrow/missing_registry.rs
+++ b/support/teliox/src/processor/escrow/missing_registry.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use keri_core::{
-    database::redb::{RedbDatabase, WriteTxnMode},
+    database::{redb::WriteTxnMode, EventDatabase},
     prefix::IdentifierPrefix,
     processor::event_storage::EventStorage,
 };
@@ -18,17 +18,17 @@ use crate::{
     },
 };
 
-pub struct MissingRegistryEscrow<D: TelEventDatabase> {
+pub struct MissingRegistryEscrow<D: TelEventDatabase, K: EventDatabase> {
     tel_reference: Arc<TelEventStorage<D>>,
-    kel_reference: Arc<EventStorage<RedbDatabase>>,
+    kel_reference: Arc<EventStorage<K>>,
     // Key is the registry id, value is the escrowed tel events digests
     escrowed_missing_registry: DigestKeyDatabase,
 }
 
-impl<D: TelEventDatabase> MissingRegistryEscrow<D> {
+impl<D: TelEventDatabase, K: EventDatabase> MissingRegistryEscrow<D, K> {
     pub fn new(
         tel_reference: Arc<D>,
-        kel_reference: Arc<EventStorage<RedbDatabase>>,
+        kel_reference: Arc<EventStorage<K>>,
         escrow_db: &EscrowDatabase,
         duration: Duration,
     ) -> Self {
@@ -42,7 +42,7 @@ impl<D: TelEventDatabase> MissingRegistryEscrow<D> {
     }
 }
 
-impl<D: TelEventDatabase + TelLogDatabase> TelNotifier for MissingRegistryEscrow<D> {
+impl<D: TelEventDatabase + TelLogDatabase, K: EventDatabase> TelNotifier for MissingRegistryEscrow<D, K> {
     fn notify(
         &self,
         notification: &TelNotification,
@@ -69,7 +69,7 @@ impl<D: TelEventDatabase + TelLogDatabase> TelNotifier for MissingRegistryEscrow
     }
 }
 
-impl<D: TelEventDatabase + TelLogDatabase> MissingRegistryEscrow<D> {
+impl<D: TelEventDatabase + TelLogDatabase, K: EventDatabase> MissingRegistryEscrow<D, K> {
     pub fn process_missing_registry(
         &self,
         bus: &TelNotificationBus,

--- a/support/teliox/src/processor/escrow/mod.rs
+++ b/support/teliox/src/processor/escrow/mod.rs
@@ -1,9 +1,9 @@
 use std::{sync::Arc, time::Duration};
 
-use keri_core::{database::redb::RedbDatabase, processor::event_storage::EventStorage};
+use keri_core::{database::EventDatabase, processor::event_storage::EventStorage};
 
 use crate::{
-    database::{redb::RedbTelDatabase, EscrowDatabase},
+    database::{EscrowDatabase, TelEventDatabase, TelLogDatabase},
     error::Error,
     processor::notification::TelNotificationKind,
 };
@@ -19,16 +19,16 @@ pub mod missing_issuer;
 pub mod missing_registry;
 pub mod out_of_order;
 
-pub fn default_escrow_bus(
-    tel_storage: Arc<RedbTelDatabase>,
-    kel_storage: Arc<EventStorage<RedbDatabase>>,
+pub fn default_escrow_bus<D: TelEventDatabase + TelLogDatabase + Send + Sync + 'static, K: EventDatabase + Send + Sync + 'static>(
+    tel_storage: Arc<D>,
+    kel_storage: Arc<EventStorage<K>>,
     tel_escrow_db: EscrowDatabase,
 ) -> Result<
     (
         TelNotificationBus,
-        Arc<MissingIssuerEscrow<RedbTelDatabase>>,
-        Arc<OutOfOrderEscrow<RedbTelDatabase>>,
-        Arc<MissingRegistryEscrow<RedbTelDatabase>>,
+        Arc<MissingIssuerEscrow<D, K>>,
+        Arc<OutOfOrderEscrow<D, K>>,
+        Arc<MissingRegistryEscrow<D, K>>,
     ),
     Error,
 > {

--- a/support/teliox/src/processor/escrow/out_of_order.rs
+++ b/support/teliox/src/processor/escrow/out_of_order.rs
@@ -2,8 +2,8 @@ use std::{sync::Arc, time::Duration};
 
 use keri_core::{
     database::{
-        redb::{escrow_database::SnKeyDatabase, RedbDatabase, WriteTxnMode},
-        SequencedEventDatabase,
+        redb::{escrow_database::SnKeyDatabase, WriteTxnMode},
+        EventDatabase, SequencedEventDatabase,
     },
     prefix::IdentifierPrefix,
     processor::event_storage::EventStorage,
@@ -19,17 +19,17 @@ use crate::{
     },
 };
 
-pub struct OutOfOrderEscrow<D: TelEventDatabase + TelLogDatabase> {
+pub struct OutOfOrderEscrow<D: TelEventDatabase + TelLogDatabase, K: EventDatabase> {
     tel_reference: Arc<TelEventStorage<D>>,
-    kel_reference: Arc<EventStorage<RedbDatabase>>,
+    kel_reference: Arc<EventStorage<K>>,
     tel_log: Arc<D>,
     escrowed_out_of_order: SnKeyDatabase,
 }
 
-impl<D: TelEventDatabase + TelLogDatabase> OutOfOrderEscrow<D> {
+impl<D: TelEventDatabase + TelLogDatabase, K: EventDatabase> OutOfOrderEscrow<D, K> {
     pub fn new(
         tel_reference: Arc<D>,
-        kel_reference: Arc<EventStorage<RedbDatabase>>,
+        kel_reference: Arc<EventStorage<K>>,
         escrow_db: &EscrowDatabase,
         duration: Duration,
     ) -> Self {
@@ -44,7 +44,7 @@ impl<D: TelEventDatabase + TelLogDatabase> OutOfOrderEscrow<D> {
     }
 }
 
-impl<D: TelEventDatabase + TelLogDatabase> TelNotifier for OutOfOrderEscrow<D> {
+impl<D: TelEventDatabase + TelLogDatabase, K: EventDatabase> TelNotifier for OutOfOrderEscrow<D, K> {
     fn notify(
         &self,
         notification: &TelNotification,
@@ -72,7 +72,7 @@ impl<D: TelEventDatabase + TelLogDatabase> TelNotifier for OutOfOrderEscrow<D> {
     }
 }
 
-impl<D: TelEventDatabase + TelLogDatabase> OutOfOrderEscrow<D> {
+impl<D: TelEventDatabase + TelLogDatabase, K: EventDatabase> OutOfOrderEscrow<D, K> {
     pub fn process_out_of_order_events(
         &self,
         bus: &TelNotificationBus,

--- a/support/teliox/src/processor/mod.rs
+++ b/support/teliox/src/processor/mod.rs
@@ -15,6 +15,7 @@ use self::{
     validator::TelEventValidator,
 };
 
+#[cfg(feature = "storage-redb")]
 pub mod escrow;
 pub mod notification;
 pub mod storage;

--- a/support/teliox/src/tel/mod.rs
+++ b/support/teliox/src/tel/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     state::{vc_state::TelState, ManagerTelState},
 };
 use keri_core::{
-    database::{redb::RedbDatabase, EventDatabase}, prefix::IdentifierPrefix, processor::event_storage::EventStorage,
+    database::EventDatabase, prefix::IdentifierPrefix, processor::event_storage::EventStorage,
 };
 use said::SelfAddressingIdentifier;
 


### PR DESCRIPTION
Introduces `OobiStorageBackend` trait, making `OobiManager<S>` generic over storage

### Changes 

- Adds `PostgresOobiStorage` implementing the trait via sqlx (`feature = "oobi-manager"`)
- Moves `RedbOobiStorage` behind `#[cfg(feature = "storage-redb")]`
- Fixes `get_end_role` returning `Some([])` instead of `None` on empty results
- Propagates `OobiManager::new` `Result` with `?` at all call sites
- Adds `From<OobiError>` conversions across controller, witness, watcher, and `keri_core::Error

