### PR TITLE
feat(keri-keyprovider): decoupled key storage with multiple backends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "components/watcher",
     "components/controller",
     "keriox_sdk",
+    "keri_keyprovider",
 ]
 
 [workspace.package]

--- a/components/controller/Cargo.toml
+++ b/components/controller/Cargo.toml
@@ -29,6 +29,7 @@ rusqlite = { version = "0.32.1", features = ["bundled"], optional = true}
 serde = "1.0.219"
 reqwest = "0.12.22"
 async-trait = "0.1.57"
+tracing = "0.1"
 
 [dev-dependencies]
 witness = { path = "../witness" }

--- a/components/watcher/Cargo.toml
+++ b/components/watcher/Cargo.toml
@@ -29,6 +29,8 @@ thiserror = "1.0.63"
 regex = "1.10.6"
 tokio = { version = "1", features = ["full"] }
 reqwest = "0.12.22"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 keri-controller = { path = "../controller" }

--- a/components/watcher/src/http_routing.rs
+++ b/components/watcher/src/http_routing.rs
@@ -34,5 +34,9 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
         "/query/tel",
         actix_web::web::post().to(http_handlers::process_tel_query_redb),
     )
-    .route("info", actix_web::web::get().to(http_handlers::info));
+    .route("info", actix_web::web::get().to(http_handlers::info))
+    .route(
+        "/health",
+        actix_web::web::get().to(http_handlers::health_redb),
+    );
 }

--- a/components/watcher/src/lib.rs
+++ b/components/watcher/src/lib.rs
@@ -1,5 +1,5 @@
 pub use crate::{
-    watcher::{config::WatcherConfig, Watcher},
+    watcher::{config::WatcherConfig, health::WitnessHealthTracker, poller::WitnessPoller, Watcher},
     watcher_listener::WatcherListener,
 };
 

--- a/components/watcher/src/main.rs
+++ b/components/watcher/src/main.rs
@@ -18,6 +18,7 @@ use url::Url;
 use tracing::info;
 use watcher::{transport::HttpTelTransport, WatcherConfig, WatcherListener};
 
+#[serde_as]
 #[derive(Deserialize)]
 pub struct Config {
     db_path: PathBuf,
@@ -37,6 +38,12 @@ pub struct Config {
     escrow_config: EscrowConfig,
 
     tel_storage_path: PathBuf,
+
+    /// Interval in seconds between background witness polling cycles.
+    /// Defaults to 30 seconds. Set to 0 to disable.
+    #[serde_as(as = "Option<DurationSeconds>")]
+    #[serde(default)]
+    poll_interval: Option<Duration>,
 }
 
 #[serde_as]
@@ -145,6 +152,7 @@ async fn main() -> anyhow::Result<()> {
         tel_transport: Box::new(HttpTelTransport),
         escrow_config: cfg.escrow_config,
         tel_storage_path: cfg.tel_storage_path,
+        poll_interval: cfg.poll_interval.unwrap_or(Duration::from_secs(30)),
     })?;
 
     // Resolve oobi to know how to find witness

--- a/components/watcher/src/main.rs
+++ b/components/watcher/src/main.rs
@@ -15,6 +15,7 @@ use keri_core::{
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DurationSeconds};
 use url::Url;
+use tracing::info;
 use watcher::{transport::HttpTelTransport, WatcherConfig, WatcherListener};
 
 #[derive(Deserialize)]
@@ -119,8 +120,15 @@ const ENV_PREFIX: &str = "WATCHER_";
 
 #[actix_web::main]
 async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
     let args = Args::parse();
-    println!("Using config file: {:?}", args.config_file);
+    info!(config_file = %args.config_file, "Loading configuration");
 
     let cfg = Figment::new()
         .merge(Yaml::file(args.config_file.clone()))
@@ -150,14 +158,11 @@ async fn main() -> anyhow::Result<()> {
         url: cfg.public_url.clone(),
     };
 
-    println!(
-        "Watcher {} is listening on port {}",
-        watcher_id.to_str(),
-        cfg.http_port,
-    );
-    println!(
-        "Watcher's oobi: {}",
-        serde_json::to_string(&watcher_loc_scheme).unwrap()
+    info!(
+        watcher_id = %watcher_id.to_str(),
+        port = cfg.http_port,
+        oobi = %serde_json::to_string(&watcher_loc_scheme).unwrap(),
+        "Watcher started",
     );
 
     watcher_listener

--- a/components/watcher/src/transport.rs
+++ b/components/watcher/src/transport.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use keri_core::oobi::{LocationScheme, Scheme};
 use teliox::query::SignedTelQuery;
 
@@ -18,6 +20,14 @@ pub enum TransportError {
     InvalidResponse,
 }
 
+fn http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .expect("Failed to build HTTP client")
+}
+
 pub struct HttpTelTransport;
 
 #[async_trait::async_trait]
@@ -31,7 +41,7 @@ impl WatcherTelTransport for HttpTelTransport {
             Scheme::Http => location.url.join("query/tel").unwrap(),
             Scheme::Tcp => todo!(),
         };
-        let resp = reqwest::Client::new()
+        let resp = http_client()
             .post(url)
             .body(qry.to_cesr().unwrap())
             .send()

--- a/components/watcher/src/watcher/config.rs
+++ b/components/watcher/src/watcher/config.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 
 use keri_core::{
     processor::escrow::EscrowConfig,
@@ -15,6 +15,9 @@ pub struct WatcherConfig {
     pub tel_transport: Box<dyn WatcherTelTransport + Send + Sync>,
     pub tel_storage_path: PathBuf,
     pub escrow_config: EscrowConfig,
+    /// Interval between background witness polling cycles.
+    /// Set to Duration::ZERO to disable polling.
+    pub poll_interval: Duration,
 }
 
 impl Default for WatcherConfig {
@@ -27,6 +30,7 @@ impl Default for WatcherConfig {
             tel_transport: Box::new(HttpTelTransport),
             tel_storage_path: PathBuf::from("tel_storage"),
             escrow_config: EscrowConfig::default(),
+            poll_interval: Duration::from_secs(30),
         }
     }
 }

--- a/components/watcher/src/watcher/health.rs
+++ b/components/watcher/src/watcher/health.rs
@@ -1,0 +1,156 @@
+use std::{
+    collections::HashMap,
+    sync::RwLock,
+    time::{Duration, Instant},
+};
+
+use keri_core::prefix::IdentifierPrefix;
+use serde::Serialize;
+
+/// Per-witness health record.
+#[derive(Debug, Clone, Serialize)]
+pub struct WitnessHealth {
+    /// Total number of successful queries.
+    pub successes: u64,
+    /// Total number of failed queries.
+    pub failures: u64,
+    /// Consecutive failures (resets on success).
+    pub consecutive_failures: u64,
+    /// Average response time in milliseconds (rolling).
+    pub avg_response_ms: f64,
+    /// Last successful contact time (seconds ago, computed at serialization).
+    #[serde(skip)]
+    pub last_success: Option<Instant>,
+    /// Last failure time.
+    #[serde(skip)]
+    pub last_failure: Option<Instant>,
+    /// Last error message.
+    pub last_error: Option<String>,
+}
+
+impl Default for WitnessHealth {
+    fn default() -> Self {
+        Self {
+            successes: 0,
+            failures: 0,
+            consecutive_failures: 0,
+            avg_response_ms: 0.0,
+            last_success: None,
+            last_failure: None,
+            last_error: None,
+        }
+    }
+}
+
+impl WitnessHealth {
+    pub fn record_success(&mut self, response_time: Duration) {
+        self.successes += 1;
+        self.consecutive_failures = 0;
+        self.last_success = Some(Instant::now());
+
+        // Rolling average
+        let ms = response_time.as_secs_f64() * 1000.0;
+        if self.successes == 1 {
+            self.avg_response_ms = ms;
+        } else {
+            // Exponential moving average with alpha = 0.2
+            self.avg_response_ms = self.avg_response_ms * 0.8 + ms * 0.2;
+        }
+    }
+
+    pub fn record_failure(&mut self, error: String) {
+        self.failures += 1;
+        self.consecutive_failures += 1;
+        self.last_failure = Some(Instant::now());
+        self.last_error = Some(error);
+    }
+
+    /// Whether this witness is considered healthy (responsive).
+    pub fn is_healthy(&self) -> bool {
+        self.consecutive_failures < 3
+    }
+}
+
+/// Aggregated health status for the watcher's view of a specific AID.
+#[derive(Debug, Clone, Serialize)]
+pub struct AidHealthStatus {
+    pub prefix: String,
+    pub total_witnesses: usize,
+    pub healthy_witnesses: usize,
+    pub degraded: bool,
+}
+
+/// Tracks health statistics for all witnesses the watcher interacts with.
+pub struct WitnessHealthTracker {
+    /// Per-witness health records keyed by witness identifier string.
+    records: RwLock<HashMap<String, WitnessHealth>>,
+}
+
+impl WitnessHealthTracker {
+    pub fn new() -> Self {
+        Self {
+            records: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Record a successful response from a witness.
+    pub fn record_success(&self, witness_id: &IdentifierPrefix, response_time: Duration) {
+        let key = witness_id.to_string();
+        let mut records = self.records.write().unwrap();
+        records
+            .entry(key)
+            .or_insert_with(WitnessHealth::default)
+            .record_success(response_time);
+    }
+
+    /// Record a failed response from a witness.
+    pub fn record_failure(&self, witness_id: &IdentifierPrefix, error: String) {
+        let key = witness_id.to_string();
+        let mut records = self.records.write().unwrap();
+        records
+            .entry(key)
+            .or_insert_with(WitnessHealth::default)
+            .record_failure(error);
+    }
+
+    /// Check if a specific witness is considered healthy.
+    pub fn is_healthy(&self, witness_id: &IdentifierPrefix) -> bool {
+        let key = witness_id.to_string();
+        let records = self.records.read().unwrap();
+        records
+            .get(&key)
+            .map(|h| h.is_healthy())
+            .unwrap_or(true) // unknown witnesses are assumed healthy
+    }
+
+    /// Get health snapshot for all tracked witnesses.
+    pub fn get_all_health(&self) -> HashMap<String, WitnessHealth> {
+        let records = self.records.read().unwrap();
+        records.clone()
+    }
+
+    /// Get health status for witnesses of a specific AID.
+    pub fn get_aid_health(
+        &self,
+        aid: &IdentifierPrefix,
+        witness_ids: &[IdentifierPrefix],
+    ) -> AidHealthStatus {
+        let records = self.records.read().unwrap();
+        let healthy_count = witness_ids
+            .iter()
+            .filter(|w| {
+                records
+                    .get(&w.to_string())
+                    .map(|h| h.is_healthy())
+                    .unwrap_or(true)
+            })
+            .count();
+
+        AidHealthStatus {
+            prefix: aid.to_string(),
+            total_witnesses: witness_ids.len(),
+            healthy_witnesses: healthy_count,
+            degraded: healthy_count == 0 && !witness_ids.is_empty(),
+        }
+    }
+}

--- a/components/watcher/src/watcher/mod.rs
+++ b/components/watcher/src/watcher/mod.rs
@@ -1,6 +1,8 @@
 pub mod config;
+pub mod health;
+pub mod poller;
 mod tel_providing;
-mod watcher_data;
+pub(crate) mod watcher_data;
 
 use std::{
     fs::create_dir_all,
@@ -20,6 +22,7 @@ use keri_core::{
     prefix::{BasicPrefix, IdentifierPrefix},
     query::reply_event::{ReplyRoute, SignedReply},
 };
+use poller::WitnessPoller;
 use tel_providing::RegistryMapping;
 use teliox::{database::redb::RedbTelDatabase, event::parse_tel_query_stream};
 use teliox::{
@@ -28,7 +31,7 @@ use teliox::{
     query::TelQueryRoute,
 };
 use tokio::sync::mpsc::{channel, Receiver};
-use watcher_data::WatcherData;
+use watcher_data::{UpdateRequest, WatcherData};
 
 use crate::WatcherConfig;
 
@@ -39,31 +42,57 @@ enum WitnessResp {
 
 pub struct Watcher<S: OobiStorageBackend> {
     pub(crate) watcher_data: Arc<WatcherData<S>>,
-    recv: Mutex<Receiver<IdentifierPrefix>>,
+    recv: Mutex<Receiver<UpdateRequest>>,
     tel_recv: Mutex<Receiver<(IdentifierPrefix, IdentifierPrefix)>>,
     // Maps registry id to witness id provided by oobi
     registry_id_mapping: RegistryMapping,
+    /// Background poller for proactively fetching KEL updates from witnesses.
+    pub(crate) poller: Arc<WitnessPoller<S>>,
 }
 
 impl<S: OobiStorageBackend> Watcher<S> {
     pub fn new(config: WatcherConfig, oobi_manager: OobiManager<S>) -> Result<Self, ActorError> {
-        let (tx, rx) = channel::<IdentifierPrefix>(100);
+        let (tx, rx) = channel::<UpdateRequest>(100);
         let (tel_tx, tel_rx) = channel::<(IdentifierPrefix, IdentifierPrefix)>(100);
         let tel_storage_path = config.tel_storage_path.clone();
+        let poll_interval = config.poll_interval;
         create_dir_all(&tel_storage_path).unwrap();
         let mut registry_ids_storage_path = tel_storage_path.clone();
         registry_ids_storage_path.push("registry");
+        let watcher_data = WatcherData::new(config, tx, tel_tx, oobi_manager)?;
+        let poller = Arc::new(WitnessPoller::new(watcher_data.clone(), poll_interval));
         Ok(Watcher {
-            watcher_data: WatcherData::new(config, tx, tel_tx, oobi_manager)?,
+            watcher_data,
             recv: Mutex::new(rx),
             tel_recv: Mutex::new(tel_rx),
             registry_id_mapping: RegistryMapping::new(&registry_ids_storage_path)
                 .map_err(|e| ActorError::GeneralError(e.to_string()))?,
+            poller,
         })
     }
 
     pub fn prefix(&self) -> BasicPrefix {
         self.watcher_data.prefix.clone()
+    }
+
+    /// Register an AID for proactive background polling.
+    pub fn track_aid(&self, id: IdentifierPrefix) {
+        self.poller.track_aid(id);
+    }
+
+    /// Remove an AID from background polling.
+    pub fn untrack_aid(&self, id: &IdentifierPrefix) {
+        self.poller.untrack_aid(id);
+    }
+
+    /// Subscribe to an AID for priority polling at the base interval.
+    pub fn subscribe_aid(&self, id: IdentifierPrefix) {
+        self.poller.subscribe(id);
+    }
+
+    /// Unsubscribe from priority polling. AID remains tracked with adaptive intervals.
+    pub fn unsubscribe_aid(&self, id: &IdentifierPrefix) {
+        self.poller.unsubscribe(id);
     }
 
     pub fn signed_location(&self, eid: &IdentifierPrefix) -> Result<Vec<SignedReply>, ActorError> {
@@ -73,8 +102,12 @@ impl<S: OobiStorageBackend> Watcher<S> {
     pub async fn process_update_requests(&self) {
         let mut recv = self.recv.lock().unwrap();
 
-        while let Some(received) = recv.recv().await {
-            let _ = self.watcher_data.update_local_kel(&received).await;
+        while let Some(request) = recv.recv().await {
+            let result = self.watcher_data.update_local_kel(&request.id).await;
+            // Signal completion if a waiter is listening.
+            if let Some(done) = request.completion {
+                let _ = done.send(result);
+            }
         }
     }
 
@@ -179,7 +212,8 @@ impl<S: OobiStorageBackend> Watcher<S> {
                     }
                 }
             }
-            //
+            // Auto-track the AID for proactive polling
+            self.poller.track_aid(er.cid.clone());
             Ok(())
         } else {
             Err(OobiError::InvalidMessageType)?

--- a/components/watcher/src/watcher/poller.rs
+++ b/components/watcher/src/watcher/poller.rs
@@ -1,0 +1,241 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+    time::{Duration, Instant},
+};
+
+use keri_core::{
+    oobi_manager::storage::OobiStorageBackend,
+    prefix::IdentifierPrefix,
+};
+use tokio::time::sleep;
+
+use super::watcher_data::WatcherData;
+
+/// Tracks the polling state for a single AID.
+#[derive(Debug, Clone)]
+struct TrackedAid {
+    /// Last known sequence number from witnesses.
+    last_known_sn: u64,
+    /// When this AID was last polled.
+    last_polled: Option<Instant>,
+    /// When the SN last changed (used for adaptive intervals).
+    last_changed: Option<Instant>,
+    /// Whether this AID has active subscribers (higher priority).
+    subscribed: bool,
+}
+
+impl TrackedAid {
+    fn new() -> Self {
+        Self {
+            last_known_sn: 0,
+            last_polled: None,
+            last_changed: None,
+            subscribed: false,
+        }
+    }
+
+    /// Compute the effective poll interval for this AID.
+    /// Recently active AIDs are polled more frequently.
+    /// Subscribed AIDs get the base interval.
+    /// Stable AIDs get progressively longer intervals.
+    fn effective_interval(&self, base_interval: Duration) -> Duration {
+        if self.subscribed {
+            return base_interval;
+        }
+
+        let idle_time = self
+            .last_changed
+            .map(|t| t.elapsed())
+            .unwrap_or(Duration::from_secs(3600));
+
+        if idle_time < Duration::from_secs(60) {
+            // Changed in the last minute — poll at base rate
+            base_interval
+        } else if idle_time < Duration::from_secs(300) {
+            // Changed in the last 5 minutes — poll at 2x base
+            base_interval * 2
+        } else if idle_time < Duration::from_secs(3600) {
+            // Changed in the last hour — poll at 5x base
+            base_interval * 5
+        } else {
+            // Stable for over an hour — poll at 10x base
+            base_interval * 10
+        }
+    }
+
+    /// Whether this AID should be polled now based on its adaptive interval.
+    fn should_poll(&self, base_interval: Duration) -> bool {
+        match self.last_polled {
+            None => true,
+            Some(last) => last.elapsed() >= self.effective_interval(base_interval),
+        }
+    }
+}
+
+/// Background poller that periodically queries witnesses for KSN updates
+/// on all tracked AIDs, ensuring the watcher's local KEL stays current
+/// without relying on external query triggers.
+///
+/// Features adaptive polling intervals:
+/// - Recently active AIDs are polled at the base rate
+/// - Stable (unchanged) AIDs are polled less frequently
+/// - Subscribed AIDs always get the base rate regardless of activity
+pub struct WitnessPoller<S: OobiStorageBackend> {
+    watcher_data: Arc<WatcherData<S>>,
+    tracked_aids: Arc<RwLock<HashMap<IdentifierPrefix, TrackedAid>>>,
+    poll_interval: Duration,
+}
+
+impl<S: OobiStorageBackend> WitnessPoller<S> {
+    pub fn new(watcher_data: Arc<WatcherData<S>>, poll_interval: Duration) -> Self {
+        Self {
+            watcher_data,
+            tracked_aids: Arc::new(RwLock::new(HashMap::new())),
+            poll_interval,
+        }
+    }
+
+    /// Register an AID for periodic polling.
+    pub fn track_aid(&self, id: IdentifierPrefix) {
+        let mut tracked = self.tracked_aids.write().unwrap();
+        tracked.entry(id).or_insert_with(TrackedAid::new);
+    }
+
+    /// Remove an AID from periodic polling.
+    pub fn untrack_aid(&self, id: &IdentifierPrefix) {
+        let mut tracked = self.tracked_aids.write().unwrap();
+        tracked.remove(id);
+    }
+
+    /// Subscribe to an AID — it will always be polled at the base interval
+    /// regardless of activity level. Automatically tracks the AID if not already tracked.
+    pub fn subscribe(&self, id: IdentifierPrefix) {
+        let mut tracked = self.tracked_aids.write().unwrap();
+        let entry = tracked.entry(id).or_insert_with(TrackedAid::new);
+        entry.subscribed = true;
+    }
+
+    /// Unsubscribe from an AID — it will fall back to adaptive polling intervals.
+    /// The AID remains tracked; use `untrack_aid` to stop polling entirely.
+    pub fn unsubscribe(&self, id: &IdentifierPrefix) {
+        let mut tracked = self.tracked_aids.write().unwrap();
+        if let Some(entry) = tracked.get_mut(id) {
+            entry.subscribed = false;
+        }
+    }
+
+    /// Get the list of currently tracked AIDs.
+    pub fn tracked_aid_ids(&self) -> Vec<IdentifierPrefix> {
+        let tracked = self.tracked_aids.read().unwrap();
+        tracked.keys().cloned().collect()
+    }
+
+    /// Run the polling loop. This should be spawned as a background task.
+    pub async fn run(&self) {
+        if self.poll_interval.is_zero() {
+            tracing::info!("Witness polling disabled (interval = 0)");
+            return;
+        }
+
+        tracing::info!(
+            interval_secs = self.poll_interval.as_secs(),
+            "Starting witness poller"
+        );
+
+        loop {
+            self.poll_due_aids().await;
+            // Sleep for a fraction of the base interval to check due AIDs more often
+            sleep(self.poll_interval / 2).await;
+        }
+    }
+
+    /// Poll only AIDs whose adaptive interval has elapsed.
+    async fn poll_due_aids(&self) {
+        let due_aids: Vec<(IdentifierPrefix, TrackedAid)> = {
+            let tracked = self.tracked_aids.read().unwrap();
+            tracked
+                .iter()
+                .filter(|(_, t)| t.should_poll(self.poll_interval))
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect()
+        };
+
+        if due_aids.is_empty() {
+            return;
+        }
+
+        tracing::debug!(
+            due = due_aids.len(),
+            total = self.tracked_aids.read().unwrap().len(),
+            "Polling due AIDs"
+        );
+
+        for (aid, tracked) in due_aids {
+            match self.poll_aid(&aid, &tracked).await {
+                Ok(new_sn) => {
+                    let mut tracked_map = self.tracked_aids.write().unwrap();
+                    if let Some(entry) = tracked_map.get_mut(&aid) {
+                        entry.last_polled = Some(Instant::now());
+                        if new_sn > entry.last_known_sn {
+                            tracing::info!(
+                                prefix = %aid,
+                                old_sn = entry.last_known_sn,
+                                new_sn = new_sn,
+                                "AID updated via polling"
+                            );
+                            entry.last_known_sn = new_sn;
+                            entry.last_changed = Some(Instant::now());
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        prefix = %aid,
+                        error = %e,
+                        "Failed to poll AID"
+                    );
+                    // Still update last_polled to avoid hammering on errors
+                    let mut tracked_map = self.tracked_aids.write().unwrap();
+                    if let Some(entry) = tracked_map.get_mut(&aid) {
+                        entry.last_polled = Some(Instant::now());
+                    }
+                }
+            }
+        }
+    }
+
+    /// Poll witnesses for a single AID. Returns the new SN after update.
+    async fn poll_aid(
+        &self,
+        aid: &IdentifierPrefix,
+        tracked: &TrackedAid,
+    ) -> Result<u64, keri_core::actor::error::ActorError> {
+        // Query witnesses for latest KSN
+        let witness_sn = self.watcher_data.query_state(aid).await?;
+
+        if witness_sn > tracked.last_known_sn {
+            // Fetch missing KEL events
+            let local_sn = self
+                .watcher_data
+                .event_storage
+                .get_state(aid)
+                .map(|s| s.sn)
+                .unwrap_or(0);
+
+            if local_sn < witness_sn {
+                self.watcher_data
+                    .forward_query_from(aid, local_sn)
+                    .await?;
+            }
+        }
+
+        // Return the current SN (local state after potential update)
+        Ok(self
+            .watcher_data
+            .event_storage
+            .get_state(aid)
+            .map(|s| s.sn)
+            .unwrap_or(0))
+    }
+}

--- a/components/watcher/src/watcher/watcher_data.rs
+++ b/components/watcher/src/watcher/watcher_data.rs
@@ -47,7 +47,14 @@ use tokio::sync::mpsc::Sender;
 
 use crate::transport::WatcherTelTransport;
 
-use super::{config::WatcherConfig, tel_providing::TelToForward};
+use super::{config::WatcherConfig, health::WitnessHealthTracker, tel_providing::TelToForward};
+
+/// A KEL update request with an optional completion signal.
+pub(crate) struct UpdateRequest {
+    pub id: IdentifierPrefix,
+    /// If set, the sender will be notified when the update completes.
+    pub completion: Option<tokio::sync::oneshot::Sender<Result<(), ActorError>>>,
+}
 
 pub struct WatcherData<S: OobiStorageBackend> {
     pub address: url::Url,
@@ -59,17 +66,18 @@ pub struct WatcherData<S: OobiStorageBackend> {
     pub transport: Box<dyn Transport + Send + Sync>,
     pub tel_transport: Box<dyn WatcherTelTransport + Send + Sync>,
     /// Watcher will update KEL of the identifiers that have been sent to this channel.
-    tx: Sender<IdentifierPrefix>,
+    tx: Sender<UpdateRequest>,
     /// Watcher will update TEL of the identifiers (registry_id, vc_id) that have been sent to this channel.
     pub tel_tx: Sender<(IdentifierPrefix, IdentifierPrefix)>,
     pub(super) tel_to_forward: Arc<TelToForward>,
     reply_escrow: Arc<ReplyEscrow<RedbDatabase>>,
+    pub(crate) health_tracker: Arc<WitnessHealthTracker>,
 }
 
 impl<S: OobiStorageBackend> WatcherData<S> {
-    pub fn new(
+    pub(crate) fn new(
         config: WatcherConfig,
-        tx: Sender<IdentifierPrefix>,
+        tx: Sender<UpdateRequest>,
         tel_tx: Sender<(IdentifierPrefix, IdentifierPrefix)>,
         oobi_manager: OobiManager<S>,
     ) -> Result<Arc<Self>, ActorError> {
@@ -81,6 +89,7 @@ impl<S: OobiStorageBackend> WatcherData<S> {
             escrow_config,
             tel_storage_path,
             tel_transport,
+            poll_interval: _, // handled by Watcher, not WatcherData
         } = config;
         let mut tel_to_forward_path = tel_storage_path.clone();
         tel_to_forward_path.push("to_forward");
@@ -149,6 +158,7 @@ impl<S: OobiStorageBackend> WatcherData<S> {
             tel_tx,
             tel_transport,
             reply_escrow,
+            health_tracker: Arc::new(WitnessHealthTracker::new()),
         });
         Ok(watcher.clone())
     }
@@ -262,29 +272,65 @@ impl<S: OobiStorageBackend> WatcherData<S> {
                 args,
             } => {
                 let local_state = self.get_state_for_prefix(&args.i);
-                match (local_state, args.s, args.limit) {
-                    (Some(state), Some(sn), Some(limit)) if sn + limit - 1 <= state.sn => {
-                        // KEL is already in database
-                    }
-                    (Some(state), Some(sn), None) if sn <= state.sn => {
-                        // KEL is already in database
-                    }
-                    (Some(_state), None, None) => {
-                        // Check for updates.
-                        let id_to_update = qry.query.get_prefix();
-                        self.tx.send(id_to_update.clone()).await.map_err(|_e| {
-                            ActorError::GeneralError("Internal watcher error".to_string())
-                        })?;
-                    }
-                    _ => {
-                        // query watcher and return info, that it's not ready
-                        let id_to_update = qry.query.get_prefix();
-                        self.tx.send(id_to_update.clone()).await.map_err(|_e| {
-                            ActorError::GeneralError("Internal watcher error".to_string())
-                        })?;
-                        return Err(ActorError::NotFound(id_to_update));
-                    }
+                let needs_update = match (local_state, args.s, args.limit) {
+                    (Some(state), Some(sn), Some(limit)) if sn + limit - 1 <= state.sn => false,
+                    (Some(state), Some(sn), None) if sn <= state.sn => false,
+                    _ => true,
                 };
+
+                if needs_update {
+                    let id_to_update = qry.query.get_prefix();
+                    // Send update request and await its completion with a timeout.
+                    let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+                    self.tx
+                        .send(UpdateRequest {
+                            id: id_to_update.clone(),
+                            completion: Some(done_tx),
+                        })
+                        .await
+                        .map_err(|_e| {
+                            ActorError::GeneralError("Internal watcher error".to_string())
+                        })?;
+
+                    // Wait up to 10 seconds for the update to complete.
+                    match tokio::time::timeout(
+                        std::time::Duration::from_secs(10),
+                        done_rx,
+                    )
+                    .await
+                    {
+                        Ok(Ok(Ok(()))) => {
+                            // Update succeeded, check if we now have the data
+                            let updated_state = self.get_state_for_prefix(&args.i);
+                            let still_missing = match (updated_state, args.s, args.limit) {
+                                (Some(state), Some(sn), Some(limit))
+                                    if sn + limit - 1 <= state.sn =>
+                                {
+                                    false
+                                }
+                                (Some(state), Some(sn), None) if sn <= state.sn => false,
+                                (None, _, _) => true,
+                                _ => true,
+                            };
+                            if still_missing {
+                                return Err(ActorError::NotFound(id_to_update));
+                            }
+                        }
+                        Ok(Ok(Err(e))) => {
+                            tracing::warn!(error = %e, "KEL update failed");
+                            return Err(ActorError::NotFound(id_to_update));
+                        }
+                        Ok(Err(_)) => {
+                            // Completion channel dropped — update task died
+                            return Err(ActorError::NotFound(id_to_update));
+                        }
+                        Err(_) => {
+                            // Timeout
+                            tracing::warn!(prefix = %id_to_update, "KEL update timed out");
+                            return Err(ActorError::NotFound(id_to_update));
+                        }
+                    }
+                }
             }
             QueryRoute::Ksn {
                 reply_route: _,
@@ -330,21 +376,34 @@ impl<S: OobiStorageBackend> WatcherData<S> {
     }
 
     pub async fn update_local_kel(&self, id: &IdentifierPrefix) -> Result<(), ActorError> {
-        // Update latest state for prefix
-        let _ = self.query_state(id).await;
+        // Query all witnesses for the latest KSN and get the highest reported SN.
+        let witness_sn = self.query_state(id).await?;
 
-        let escrowed_replies = self
-            .reply_escrow
-            .get_all(&id)
-            .into_iter()
-            .flatten()
-            .collect_vec();
+        // Compare against locally stored KEL state.
+        let local_sn = self
+            .event_storage
+            .get_state(id)
+            .map(|s| s.sn)
+            .unwrap_or(0);
 
-        if !escrowed_replies.is_empty() {
-            // If there is an escrowed reply it means we don't have the most recent data.
-            // In this case forward the query to witness.
-            self.forward_query(id).await?;
-        };
+        if local_sn < witness_sn {
+            // We are behind — fetch the missing KEL events from witnesses.
+            self.forward_query_from(id, local_sn).await?;
+        } else {
+            // Even if SN matches, check if there are escrowed replies waiting
+            // for events we may have missed (e.g. receipts, delegations).
+            let escrowed_replies = self
+                .reply_escrow
+                .get_all(&id)
+                .into_iter()
+                .flatten()
+                .collect_vec();
+
+            if !escrowed_replies.is_empty() {
+                self.forward_query_from(id, local_sn).await?;
+            }
+        }
+
         Ok(())
     }
 
@@ -359,7 +418,12 @@ impl<S: OobiStorageBackend> WatcherData<S> {
     }
 
     /// Forward query to registered witnesses and save its response to mailbox.
-    async fn forward_query(&self, id: &IdentifierPrefix) -> Result<(), ActorError> {
+    /// Fetches events starting from `from_sn` to avoid re-fetching the entire KEL.
+    pub(crate) async fn forward_query_from(
+        &self,
+        id: &IdentifierPrefix,
+        from_sn: u64,
+    ) -> Result<(), ActorError> {
         let witnesses = self.get_witnesses_for_prefix(&id)?;
         for witness in witnesses {
             let witness_id = IdentifierPrefix::Basic(witness);
@@ -367,7 +431,7 @@ impl<S: OobiStorageBackend> WatcherData<S> {
                 reply_route: "".to_string(),
                 args: LogsQueryArgs {
                     i: id.clone(),
-                    s: None,
+                    s: if from_sn > 0 { Some(from_sn) } else { None },
                     src: Some(witness_id.clone()),
                     limit: None,
                 },
@@ -388,7 +452,20 @@ impl<S: OobiStorageBackend> WatcherData<S> {
                     keri_core::oobi::Scheme::Http,
                     signed_qry,
                 )
-                .await?;
+                .await;
+
+            let resp = match resp {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::warn!(
+                        witness = %witness_id,
+                        prefix = %id,
+                        error = %e,
+                        "Failed to fetch KEL from witness, trying next"
+                    );
+                    continue;
+                }
+            };
 
             match resp {
                 PossibleResponse::Ksn(rpy) => {
@@ -405,7 +482,7 @@ impl<S: OobiStorageBackend> WatcherData<S> {
                     }
                 }
                 PossibleResponse::Mbx(_mbx) => {
-                    panic!("Unexpected response type MBX");
+                    tracing::error!("Unexpected MBX response from witness {}", witness_id);
                 }
             }
         }
@@ -413,18 +490,46 @@ impl<S: OobiStorageBackend> WatcherData<S> {
         Ok(())
     }
 
-    /// Query witness about KSN for given prefix and save its response to db.
-    /// Returns ID of witness that responded.
-    async fn query_state(&self, prefix: &IdentifierPrefix) -> Result<(), ActorError> {
+    /// Query all witnesses about KSN for given prefix.
+    /// Returns the highest SN reported by any witness.
+    pub(crate) async fn query_state(&self, prefix: &IdentifierPrefix) -> Result<u64, ActorError> {
         let wits_id = self.get_witnesses_for_prefix(&prefix)?;
-        let _r: Vec<Result<_, _>> = join_all(wits_id.into_iter().map(|id| {
+        let results: Vec<Result<u64, ActorError>> = join_all(wits_id.into_iter().map(|id| {
             let id = IdentifierPrefix::Basic(id);
-
             self.ksn_update(&prefix, id)
         }))
         .await;
 
-        Ok(())
+        let mut max_sn: u64 = 0;
+        let mut any_success = false;
+        for result in results {
+            match result {
+                Ok(sn) => {
+                    any_success = true;
+                    if sn > max_sn {
+                        max_sn = sn;
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        prefix = %prefix,
+                        error = %e,
+                        "Failed to get KSN from witness"
+                    );
+                }
+            }
+        }
+
+        if !any_success && max_sn == 0 {
+            // Fall back to local state if all witnesses failed
+            max_sn = self
+                .event_storage
+                .get_state(prefix)
+                .map(|s| s.sn)
+                .unwrap_or(0);
+        }
+
+        Ok(max_sn)
     }
 
     pub(crate) async fn tel_update(
@@ -475,11 +580,13 @@ impl<S: OobiStorageBackend> WatcherData<S> {
         Ok(())
     }
 
+    /// Query a specific witness for the KSN of a prefix.
+    /// Returns the SN reported by the witness.
     async fn ksn_update(
         &self,
         about_id: &IdentifierPrefix,
         wit_id: IdentifierPrefix,
-    ) -> Result<(), ActorError> {
+    ) -> Result<u64, ActorError> {
         let query_args = LogsQueryArgs {
             i: about_id.clone(),
             s: None,
@@ -504,15 +611,38 @@ impl<S: OobiStorageBackend> WatcherData<S> {
             )?,
         );
         let query = SignedKelQuery::new_nontrans(qry, self.prefix.clone(), signature);
-        let resp = self.send_query_to(wit_id, Scheme::Http, query).await?;
+
+        let start = std::time::Instant::now();
+        let resp = match self.send_query_to(wit_id.clone(), Scheme::Http, query).await {
+            Ok(r) => r,
+            Err(e) => {
+                self.health_tracker
+                    .record_failure(&wit_id, e.to_string());
+                return Err(e);
+            }
+        };
 
         let resp = match resp {
             PossibleResponse::Ksn(ksn) => ksn,
-            e => return Err(ActorError::UnexpectedResponse(e.to_string())),
+            e => {
+                let err = ActorError::UnexpectedResponse(e.to_string());
+                self.health_tracker
+                    .record_failure(&wit_id, err.to_string());
+                return Err(err);
+            }
+        };
+
+        // Extract the SN from the KSN reply before processing it.
+        let route = resp.reply.get_route();
+        let sn = match route {
+            ReplyRoute::Ksn(_, ksn) => ksn.state.sn,
+            _ => 0,
         };
 
         self.process_reply(resp)?;
-        Ok(())
+        self.health_tracker
+            .record_success(&wit_id, start.elapsed());
+        Ok(sn)
     }
 
     /// Get witnesses for prefix

--- a/components/watcher/src/watcher/watcher_data.rs
+++ b/components/watcher/src/watcher/watcher_data.rs
@@ -425,64 +425,79 @@ impl<S: OobiStorageBackend> WatcherData<S> {
         from_sn: u64,
     ) -> Result<(), ActorError> {
         let witnesses = self.get_witnesses_for_prefix(&id)?;
-        for witness in witnesses {
+
+        // Build and send queries to all witnesses in parallel
+        let results = join_all(witnesses.into_iter().map(|witness| {
             let witness_id = IdentifierPrefix::Basic(witness);
-            let route = QueryRoute::Logs {
-                reply_route: "".to_string(),
-                args: LogsQueryArgs {
-                    i: id.clone(),
-                    s: if from_sn > 0 { Some(from_sn) } else { None },
-                    src: Some(witness_id.clone()),
-                    limit: None,
-                },
-            };
+            let id = id.clone();
+            async move {
+                let route = QueryRoute::Logs {
+                    reply_route: "".to_string(),
+                    args: LogsQueryArgs {
+                        i: id.clone(),
+                        s: if from_sn > 0 { Some(from_sn) } else { None },
+                        src: Some(witness_id.clone()),
+                        limit: None,
+                    },
+                };
 
-            let qry = QueryEvent::new_query(
-                route,
-                SerializationFormats::JSON,
-                HashFunctionCode::Blake3_256,
-            );
-            // Create a new signed message
-            let sigs = SelfSigningPrefix::Ed25519Sha512(self.signer.sign(qry.encode()?)?);
-            let signed_qry = SignedKelQuery::new_nontrans(qry.clone(), self.prefix.clone(), sigs);
+                let qry = QueryEvent::new_query(
+                    route,
+                    SerializationFormats::JSON,
+                    HashFunctionCode::Blake3_256,
+                );
+                let sigs =
+                    SelfSigningPrefix::Ed25519Sha512(self.signer.sign(qry.encode()?)?);
+                let signed_qry =
+                    SignedKelQuery::new_nontrans(qry.clone(), self.prefix.clone(), sigs);
 
-            let resp = self
-                .send_query_to(
-                    witness_id.clone(),
-                    keri_core::oobi::Scheme::Http,
-                    signed_qry,
-                )
-                .await;
+                let resp = self
+                    .send_query_to(
+                        witness_id.clone(),
+                        keri_core::oobi::Scheme::Http,
+                        signed_qry,
+                    )
+                    .await;
 
-            let resp = match resp {
-                Ok(r) => r,
-                Err(e) => {
-                    tracing::warn!(
-                        witness = %witness_id,
-                        prefix = %id,
-                        error = %e,
-                        "Failed to fetch KEL from witness, trying next"
-                    );
-                    continue;
+                match resp {
+                    Ok(r) => Ok((witness_id, r)),
+                    Err(e) => {
+                        tracing::warn!(
+                            witness = %witness_id,
+                            prefix = %id,
+                            error = %e,
+                            "Failed to fetch KEL from witness"
+                        );
+                        Err(e)
+                    }
                 }
-            };
+            }
+        }))
+        .await;
 
-            match resp {
-                PossibleResponse::Ksn(rpy) => {
-                    self.process_reply(rpy)?;
-                }
-                PossibleResponse::Kel(msgs) => {
-                    for msg in msgs {
-                        if let Message::Notice(notice) = msg {
-                            self.process_notice(notice.clone())?;
-                            if let Notice::Event(evt) = notice {
-                                self.event_storage.add_mailbox_reply(evt)?;
+        // Process all successful responses
+        for result in results {
+            if let Ok((witness_id, resp)) = result {
+                match resp {
+                    PossibleResponse::Ksn(rpy) => {
+                        self.process_reply(rpy)?;
+                    }
+                    PossibleResponse::Kel(msgs) => {
+                        for msg in msgs {
+                            if let Message::Notice(notice) = msg {
+                                self.process_notice(notice.clone())?;
+                                if let Notice::Event(evt) = notice {
+                                    self.event_storage.add_mailbox_reply(evt)?;
+                                }
                             }
                         }
                     }
-                }
-                PossibleResponse::Mbx(_mbx) => {
-                    tracing::error!("Unexpected MBX response from witness {}", witness_id);
+                    PossibleResponse::Mbx(_mbx) => {
+                        tracing::error!(
+                            "Unexpected MBX response from witness {}",
+                            witness_id
+                        );
+                    }
                 }
             }
         }

--- a/components/watcher/src/watcher_listener.rs
+++ b/components/watcher/src/watcher_listener.rs
@@ -22,7 +22,8 @@ impl<S: OobiStorageBackend + 'static> WatcherListener<S> {
     pub fn listen_http(self, addr: impl ToSocketAddrs) -> Server {
         let data = self.watcher.clone();
         spawn(update_tel_checking(data.clone()));
-        spawn(update_checking(data));
+        spawn(update_checking(data.clone()));
+        spawn(witness_polling(data));
 
         let state = web::Data::new(self.watcher);
         HttpServer::new(move || {
@@ -73,6 +74,10 @@ pub async fn update_checking<S: OobiStorageBackend>(data: Arc<Watcher<S>>) {
 
 pub async fn update_tel_checking<S: OobiStorageBackend>(data: Arc<Watcher<S>>) {
     let _ = data.process_update_tel_requests().await;
+}
+
+pub async fn witness_polling<S: OobiStorageBackend>(data: Arc<Watcher<S>>) {
+    data.poller.run().await;
 }
 
 pub mod http_handlers {
@@ -303,6 +308,30 @@ pub mod http_handlers {
         data: web::Data<Arc<Watcher<RedbOobiStorage>>>,
     ) -> Result<HttpResponse, ApiError> {
         process_tel_query(post_data, data).await
+    }
+
+    pub async fn health<S: OobiStorageBackend>(
+        data: web::Data<Arc<Watcher<S>>>,
+    ) -> Result<HttpResponse, ApiError> {
+        let witness_health = data.watcher_data.health_tracker.get_all_health();
+        let tracked_aids = data.poller.tracked_aid_ids();
+
+        #[derive(serde::Serialize)]
+        struct HealthResponse {
+            tracked_aids: usize,
+            witnesses: std::collections::HashMap<String, crate::watcher::health::WitnessHealth>,
+        }
+
+        Ok(HttpResponse::Ok().json(HealthResponse {
+            tracked_aids: tracked_aids.len(),
+            witnesses: witness_health,
+        }))
+    }
+
+    pub async fn health_redb(
+        data: web::Data<Arc<Watcher<RedbOobiStorage>>>,
+    ) -> Result<HttpResponse, ApiError> {
+        health(data).await
     }
 
     pub async fn info() -> impl Responder {

--- a/components/watcher/src/watcher_listener.rs
+++ b/components/watcher/src/watcher_listener.rs
@@ -104,10 +104,8 @@ pub mod http_handlers {
         body: web::Bytes,
         data: web::Data<Arc<Watcher<S>>>,
     ) -> Result<HttpResponse, ApiError> {
-        println!(
-            "\nGot events to process: \n{}",
-            String::from_utf8_lossy(&body)
-        );
+        tracing::info!("Processing notice");
+        tracing::debug!(payload = %String::from_utf8_lossy(&body), "Notice payload");
         data.parse_and_process_notices(&body)
             .map_err(ActorError::from)?;
 
@@ -120,17 +118,15 @@ pub mod http_handlers {
         body: web::Bytes,
         data: web::Data<Arc<Watcher<S>>>,
     ) -> Result<HttpResponse, ApiError> {
-        println!(
-            "\nGot queries to process: \n{}",
-            String::from_utf8_lossy(&body)
-        );
+        tracing::info!("Processing query");
+        tracing::debug!(payload = %String::from_utf8_lossy(&body), "Query payload");
         let resp = data
             .parse_and_process_queries(&body)
             .await?
             .iter()
             .map(|msg| msg.to_string())
             .join("");
-        println!("\nResponds with: {}", &resp);
+        tracing::debug!(response = %resp, "Query response");
 
         Ok(HttpResponse::Ok()
             .content_type(ContentType::plaintext())
@@ -141,10 +137,8 @@ pub mod http_handlers {
         body: web::Bytes,
         data: web::Data<Arc<Watcher<S>>>,
     ) -> Result<HttpResponse, ApiError> {
-        println!(
-            "\nGot replies to process: \n{}",
-            String::from_utf8_lossy(&body)
-        );
+        tracing::info!("Processing reply");
+        tracing::debug!(payload = %String::from_utf8_lossy(&body), "Reply payload");
 
         data.parse_and_process_replies(&body)?;
 
@@ -157,10 +151,8 @@ pub mod http_handlers {
         body: web::Bytes,
         data: web::Data<Arc<Watcher<S>>>,
     ) -> Result<HttpResponse, ApiError> {
-        println!(
-            "\nGot oobi to resolve: \n{}",
-            String::from_utf8_lossy(&body)
-        );
+        tracing::info!("Resolving OOBI");
+        tracing::debug!(payload = %String::from_utf8_lossy(&body), "OOBI payload");
 
         #[derive(Debug, Deserialize)]
         #[serde(untagged)]
@@ -231,7 +223,8 @@ pub mod http_handlers {
         post_data: String,
         data: web::Data<Arc<Watcher<S>>>,
     ) -> Result<HttpResponse, ApiError> {
-        println!("\nGot tel query to process: \n{}", post_data);
+        tracing::info!("Processing TEL query");
+        tracing::debug!(payload = %post_data, "TEL query payload");
         let resp = data
             .parse_and_process_tel_queries(post_data.as_bytes())
             .await?
@@ -239,7 +232,7 @@ pub mod http_handlers {
             .map(|msg| msg.to_string())
             .collect::<Vec<_>>()
             .join("");
-        println!("\nWatcher responds with: {}", resp);
+        tracing::debug!(response = %resp, "TEL query response");
         Ok(HttpResponse::Ok()
             .content_type(ContentType::plaintext())
             .body(resp))

--- a/components/witness/Cargo.toml
+++ b/components/witness/Cargo.toml
@@ -21,7 +21,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_with = "2.2.0"
 url = { version = "2.2.2", features = ["serde"] }
 keri-core = { path = "../../keriox_core", features = ["oobi-manager", "mailbox"] }
-log = "0.4.17"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde_json = "1.0"
 teliox = {path = "../../support/teliox"}
 thiserror = "1.0.43"

--- a/components/witness/src/main.rs
+++ b/components/witness/src/main.rs
@@ -13,6 +13,7 @@ use keri_core::{
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DurationSeconds};
 use url::Url;
+use tracing::{info};
 use witness::{WitnessEscrowConfig, WitnessListener};
 
 #[derive(Deserialize)]
@@ -97,9 +98,16 @@ const ENV_PREFIX: &str = "WITNESS_";
 
 #[actix_web::main]
 async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
     let args = Args::parse();
 
-    println!("Using config file {:?}", args.config_file);
+    info!(config_file = %args.config_file, "Loading configuration");
 
     let cfg = Figment::new()
         .merge(Yaml::file(args.config_file.clone()))
@@ -122,14 +130,11 @@ async fn main() -> Result<()> {
         url: cfg.public_url.clone(),
     };
 
-    println!(
-        "\nWitness {} is listening on port {}",
-        witness_listener.get_prefix().to_str(),
-        cfg.http_port,
-    );
-    println!(
-        "Witness's oobi: {}",
-        serde_json::to_string(&witness_loc_scheme).unwrap()
+    info!(
+        witness_id = %witness_listener.get_prefix().to_str(),
+        port = cfg.http_port,
+        oobi = %serde_json::to_string(&witness_loc_scheme).unwrap(),
+        "Witness started",
     );
 
     let http_handle = witness_listener.listen_http((Ipv4Addr::UNSPECIFIED, cfg.http_port));

--- a/components/witness/src/witness.rs
+++ b/components/witness/src/witness.rs
@@ -364,7 +364,7 @@ impl<S: OobiStorageBackend> Witness<S> {
         &self,
         qry: keri_core::query::query_event::SignedQueryMessage,
     ) -> Result<Option<PossibleResponse>, ActorError> {
-        println!("Processing query: {:?}", qry);
+        tracing::debug!(?qry, "Processing query");
         let response = process_signed_query(qry, &self.event_storage)?;
 
         match response {

--- a/components/witness/src/witness_listener.rs
+++ b/components/witness/src/witness_listener.rs
@@ -395,11 +395,8 @@ pub mod http_handlers {
         post_data: String,
         data: web::Data<Arc<Witness<S>>>,
     ) -> Result<HttpResponse, ApiError> {
-        println!(
-            "\nWitness {} got notice to process: \n{}",
-            &data.prefix.to_str(),
-            post_data
-        );
+        tracing::info!(witness = %data.prefix.to_str(), "Processing notice");
+        tracing::debug!(payload = %post_data, "Notice payload");
         data.parse_and_process_notices(post_data.as_bytes())
             .map_err(ActorError::KeriError)?;
         Ok(HttpResponse::Ok()
@@ -411,18 +408,15 @@ pub mod http_handlers {
         post_data: String,
         data: web::Data<Arc<Witness<S>>>,
     ) -> Result<HttpResponse, ApiError> {
-        println!(
-            "\nWitness {} got query to process: \n{}",
-            &data.prefix.to_str(),
-            post_data
-        );
+        tracing::info!(witness = %data.prefix.to_str(), "Processing query");
+        tracing::debug!(payload = %post_data, "Query payload");
         let resp = data
             .parse_and_process_queries(post_data.as_bytes())?
             .iter()
             .map(|msg| msg.to_string())
             .collect::<Vec<_>>()
             .join("");
-        println!("\nWitness responds with: {}", resp);
+        tracing::debug!(response = %resp, "Query response");
         Ok(HttpResponse::Ok()
             .content_type(ContentType::plaintext())
             .body(resp))
@@ -432,14 +426,15 @@ pub mod http_handlers {
         post_data: String,
         data: web::Data<Arc<Witness<S>>>,
     ) -> Result<HttpResponse, ApiError> {
-        println!("\nGot tel query to process: \n{}", post_data);
+        tracing::info!("Processing TEL query");
+        tracing::debug!(payload = %post_data, "TEL query payload");
         let resp = data
             .parse_and_process_tel_queries(post_data.as_bytes())?
             .iter()
             .map(|msg| msg.to_string())
             .collect::<Vec<_>>()
             .join("");
-        println!("\nWitness responds with: {}", resp);
+        tracing::debug!(response = %resp, "TEL query response");
         Ok(HttpResponse::Ok()
             .content_type(ContentType::plaintext())
             .body(resp))
@@ -449,7 +444,8 @@ pub mod http_handlers {
         post_data: String,
         data: web::Data<Arc<Witness<S>>>,
     ) -> Result<HttpResponse, ApiError> {
-        println!("\nGot reply to process: \n{}", post_data);
+        tracing::info!("Processing reply");
+        tracing::debug!(payload = %post_data, "Reply payload");
         data.parse_and_process_replies(post_data.as_bytes())?;
 
         Ok(HttpResponse::Ok()
@@ -461,7 +457,8 @@ pub mod http_handlers {
         post_data: String,
         data: web::Data<Arc<Witness<S>>>,
     ) -> Result<HttpResponse, ApiError> {
-        println!("\nGot exchange to process: \n{}", post_data);
+        tracing::info!("Processing exchange");
+        tracing::debug!(payload = %post_data, "Exchange payload");
         data.parse_and_process_exchanges(post_data.as_bytes())?;
 
         Ok(HttpResponse::Ok()
@@ -473,7 +470,8 @@ pub mod http_handlers {
         post_data: String,
         data: web::Data<Arc<Witness<S>>>,
     ) -> Result<HttpResponse, ApiError> {
-        println!("\nGot tel event to process: \n{}", post_data);
+        tracing::info!("Processing TEL event");
+        tracing::debug!(payload = %post_data, "TEL event payload");
         let parsed = VerifiableEvent::parse(post_data.as_bytes()).unwrap();
         for ev in parsed {
             data.tel.processor.process(ev).unwrap()

--- a/keri_keyprovider/Cargo.toml
+++ b/keri_keyprovider/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "keri-keyprovider"
+version = "0.1.0"
+description = "Decoupled cryptographic key provider interface for KERI and beyond"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[features]
+default = ["software"]
+software = ["ed25519-dalek", "k256", "rand"]
+file-encrypted = ["software", "chacha20poly1305", "argon2", "rpassword"]
+os-keychain = ["keyring"]
+
+[dependencies]
+async-trait = "0.1"
+thiserror = "1"
+zeroize = { version = "1", features = ["derive"] }
+
+# Software key provider
+ed25519-dalek = { version = "2.1", features = ["rand_core"], optional = true }
+k256 = { version = "0.9", features = ["ecdsa", "sha256", "zeroize"], optional = true }
+rand = { version = "0.8", optional = true }
+
+# File-encrypted provider
+chacha20poly1305 = { version = "0.10", optional = true }
+argon2 = { version = "0.5", optional = true }
+rpassword = { version = "7", optional = true }
+
+# OS keychain provider
+keyring = { version = "3", optional = true }
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["full"] }

--- a/keri_keyprovider/src/error.rs
+++ b/keri_keyprovider/src/error.rs
@@ -1,0 +1,42 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum KeyProviderError {
+    #[error("key not found: {0}")]
+    NotFound(String),
+
+    #[error("key already exists: {0}")]
+    AlreadyExists(String),
+
+    #[error("unsupported operation: {0}")]
+    UnsupportedOperation(String),
+
+    #[error("authentication failed: {0}")]
+    AuthenticationFailed(String),
+
+    #[error("key is locked; call unlock() first")]
+    Locked,
+
+    #[error("encryption error: {0}")]
+    EncryptionError(String),
+
+    #[error("invalid key material: {0}")]
+    InvalidKeyMaterial(String),
+
+    #[error("unsupported algorithm: {0}")]
+    UnsupportedAlgorithm(String),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("{0}")]
+    Other(String),
+}
+
+impl KeyProviderError {
+    pub(crate) fn unsupported(op: &str) -> Self {
+        Self::UnsupportedOperation(op.into())
+    }
+}
+
+pub type Result<T> = std::result::Result<T, KeyProviderError>;

--- a/keri_keyprovider/src/file_encrypted.rs
+++ b/keri_keyprovider/src/file_encrypted.rs
@@ -1,0 +1,515 @@
+//! Encrypted file-backed key provider.
+//!
+//! Seeds are encrypted at rest using XChaCha20-Poly1305 with a key derived
+//! from the user's passphrase via Argon2id. An auto-lock mechanism zeroes
+//! in-memory key material after a configurable timeout.
+
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use async_trait::async_trait;
+use chacha20poly1305::{
+    aead::Aead, Key, KeyInit, XChaCha20Poly1305, XNonce,
+};
+use argon2::{Argon2, Algorithm, Version};
+use rand::RngCore;
+use zeroize::Zeroize;
+
+use crate::{
+    software::SoftwareKeyProvider,
+    EncryptedKeyExport, KeyProvider, KeyProviderError, KeyProviderFactory, KdfParams, PublicKeyData,
+    Result, SignatureAlgorithm,
+};
+
+const FILE_VERSION: u8 = 1;
+const NONCE_SIZE: usize = 24;
+const SALT_SIZE: usize = 32;
+
+pub(crate) fn encrypt_seed(
+    passphrase: &[u8],
+    seed: &[u8],
+    label: &str,
+    algorithm: SignatureAlgorithm,
+) -> Result<EncryptedKeyExport> {
+    let params = KdfParams::default();
+    let mut salt = vec![0u8; SALT_SIZE];
+    rand::thread_rng().fill_bytes(&mut salt);
+    let mut nonce = [0u8; NONCE_SIZE];
+    rand::thread_rng().fill_bytes(&mut nonce);
+
+    let derived_key = derive_key(passphrase, &salt, &params)?;
+    let cipher = XChaCha20Poly1305::new(Key::from_slice(&derived_key));
+    let nonce = XNonce::from_slice(&nonce);
+    let ciphertext = cipher
+        .encrypt(nonce, seed)
+        .map_err(|e| KeyProviderError::EncryptionError(format!("encryption failed: {e}")))?;
+
+    Ok(EncryptedKeyExport {
+        version: FILE_VERSION,
+        label: label.to_string(),
+        algorithm,
+        salt,
+        nonce: nonce.to_vec(),
+        ciphertext,
+        kdf_params: params,
+    })
+}
+
+fn derive_key(passphrase: &[u8], salt: &[u8], params: &KdfParams) -> Result<[u8; 32]> {
+    let config = argon2::Params::new(params.mem_cost, params.time_cost, params.parallelism, Some(32))
+        .map_err(|e| KeyProviderError::EncryptionError(format!("invalid argon2 params: {e}")))?;
+    let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, config);
+    let mut key = [0u8; 32];
+    argon2
+        .hash_password_into(passphrase, salt, &mut key)
+        .map_err(|e| KeyProviderError::EncryptionError(format!("argon2 failed: {e}")))?;
+    Ok(key)
+}
+
+fn decrypt_seed(passphrase: &[u8], export: &EncryptedKeyExport) -> Result<Vec<u8>> {
+    let derived_key = derive_key(passphrase, &export.salt, &export.kdf_params)?;
+    let cipher = XChaCha20Poly1305::new(Key::from_slice(&derived_key));
+    let nonce = XNonce::from_slice(&export.nonce);
+    cipher
+        .decrypt(nonce, export.ciphertext.as_slice())
+        .map_err(|_| KeyProviderError::AuthenticationFailed("wrong passphrase or corrupted data".into()))
+}
+
+/// Persistent key provider backed by encrypted files on disk.
+///
+/// The key file stores:
+/// ```text
+/// version (1B) | algorithm (1B) | nonce (24B) | salt (32B) |
+/// mem_cost (4B LE) | time_cost (4B LE) | parallelism (4B LE) |
+/// ciphertext + tag
+/// ```
+///
+/// After creation or explicit unlock, the decrypted key is held in memory
+/// until the auto-lock timeout expires.
+pub struct FileEncryptedProvider {
+    label: String,
+    path: PathBuf,
+    algorithm: SignatureAlgorithm,
+    public_data: PublicKeyData,
+    auto_lock_timeout: Duration,
+    unlocked: std::sync::Mutex<UnlockedState>,
+}
+
+struct UnlockedState {
+    inner: Option<Arc<SoftwareKeyProvider>>,
+    last_used: Instant,
+    seed: Option<Vec<u8>>,
+}
+
+impl FileEncryptedProvider {
+    /// Create a new encrypted key provider, writing the encrypted seed to disk.
+    ///
+    /// The passphrase is used to derive the encryption key via Argon2id.
+    pub fn create(
+        label: impl Into<String>,
+        path: PathBuf,
+        algorithm: SignatureAlgorithm,
+        passphrase: &[u8],
+        auto_lock_timeout: Duration,
+    ) -> Result<Self> {
+        let provider = SoftwareKeyProvider::generate(label.into(), algorithm)?;
+        let seed = provider
+            .ed25519_seed_bytes()
+            .ok_or_else(|| KeyProviderError::UnsupportedAlgorithm("only Ed25519 supported".into()))?;
+
+        let export = encrypt_seed(passphrase, &seed, provider.label(), algorithm)?;
+        write_key_file(&path, &export)?;
+
+        let public_data = provider.public_key().clone();
+        let label = provider.label().to_string();
+
+        Ok(Self {
+            label,
+            path,
+            algorithm,
+            public_data,
+            auto_lock_timeout,
+            unlocked: std::sync::Mutex::new(UnlockedState {
+                inner: Some(Arc::new(provider)),
+                last_used: Instant::now(),
+                seed: Some(seed.to_vec()),
+            }),
+        })
+    }
+
+    /// Open an existing encrypted key file.
+    ///
+    /// The key remains locked until [`unlock()`](Self::unlock) is called.
+    pub fn open(
+        label: impl Into<String>,
+        path: PathBuf,
+        auto_lock_timeout: Duration,
+    ) -> Result<Self> {
+        let export = read_key_file(&path)?;
+
+        // Derive public key from the algorithm (we can't decrypt without passphrase)
+        let public_data = PublicKeyData::new(export.algorithm, vec![]);
+
+        Ok(Self {
+            label: label.into(),
+            path,
+            algorithm: export.algorithm,
+            public_data,
+            auto_lock_timeout,
+            unlocked: std::sync::Mutex::new(UnlockedState {
+                inner: None,
+                last_used: Instant::now(),
+                seed: None,
+            }),
+        })
+    }
+
+    /// Unlock the key with the given passphrase.
+    pub async fn unlock(&self, passphrase: &[u8]) -> Result<()> {
+        let export = read_key_file(&self.path)?;
+        let seed = decrypt_seed(passphrase, &export)?;
+
+        let provider = match export.algorithm {
+            SignatureAlgorithm::Ed25519 => {
+                let seed_arr: [u8; 32] = seed
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| KeyProviderError::InvalidKeyMaterial("seed must be 32 bytes".into()))?;
+                SoftwareKeyProvider::from_ed25519_bytes(&self.label, &seed_arr)?
+            }
+            SignatureAlgorithm::EcdsaSecp256k1 => {
+                return Err(KeyProviderError::UnsupportedAlgorithm(
+                    "secp256k1 file encryption not yet implemented".into(),
+                ));
+            }
+        };
+
+        let mut state = self.unlocked.lock().unwrap();
+        state.last_used = Instant::now();
+        state.inner = Some(Arc::new(provider));
+        state.seed = Some(seed);
+
+        Ok(())
+    }
+
+    async fn ensure_unlocked(&self) -> Result<()> {
+        let mut state = self.unlocked.lock().unwrap();
+        if state.inner.is_none() {
+            return Err(KeyProviderError::Locked);
+        }
+        if state.last_used.elapsed() > self.auto_lock_timeout {
+            state.inner.take();
+            if let Some(ref mut seed) = state.seed {
+                Zeroize::zeroize(seed);
+                state.seed.take();
+            }
+            return Err(KeyProviderError::Locked);
+        }
+        state.last_used = Instant::now();
+        Ok(())
+    }
+}
+
+fn write_key_file(path: &Path, export: &EncryptedKeyExport) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut buf = Vec::with_capacity(128);
+    buf.push(export.version);
+    buf.push(match export.algorithm {
+        SignatureAlgorithm::Ed25519 => 0,
+        SignatureAlgorithm::EcdsaSecp256k1 => 1,
+    });
+    buf.extend_from_slice(&export.nonce);
+    buf.extend_from_slice(&export.salt);
+    buf.extend_from_slice(&export.kdf_params.mem_cost.to_le_bytes());
+    buf.extend_from_slice(&export.kdf_params.time_cost.to_le_bytes());
+    buf.extend_from_slice(&export.kdf_params.parallelism.to_le_bytes());
+    buf.extend_from_slice(&export.ciphertext);
+
+    let mut f = std::fs::File::create(path)?;
+    f.write_all(&buf)?;
+    f.sync_all()?;
+    Ok(())
+}
+
+fn read_key_file(path: &Path) -> Result<EncryptedKeyExport> {
+    let data = std::fs::read(path)?;
+    if data.len() < 66 {
+        // 1 + 1 + 24 + 32 + 4 + 4 = 66 minimum (before ciphertext)
+        return Err(KeyProviderError::InvalidKeyMaterial("key file too short".into()));
+    }
+    let version = data[0];
+    if version != FILE_VERSION {
+        return Err(KeyProviderError::InvalidKeyMaterial(format!(
+            "unsupported key file version {version}"
+        )));
+    }
+    let algorithm = match data[1] {
+        0 => SignatureAlgorithm::Ed25519,
+        1 => SignatureAlgorithm::EcdsaSecp256k1,
+        _ => return Err(KeyProviderError::InvalidKeyMaterial("unknown algorithm code".into())),
+    };
+    let nonce = data[2..26].to_vec();
+    let salt = data[26..58].to_vec();
+    let mem_cost = u32::from_le_bytes(data[58..62].try_into().unwrap());
+    let time_cost = u32::from_le_bytes(data[62..66].try_into().unwrap());
+    let parallelism = u32::from_le_bytes(data[66..70].try_into().unwrap());
+    let ciphertext = data[70..].to_vec();
+
+    Ok(EncryptedKeyExport {
+        version,
+        label: String::new(),
+        algorithm,
+        salt,
+        nonce,
+        ciphertext,
+        kdf_params: KdfParams {
+            mem_cost,
+            time_cost,
+            parallelism,
+        },
+    })
+}
+
+#[async_trait]
+impl KeyProvider for FileEncryptedProvider {
+    async fn sign(&self, message: &[u8]) -> Result<Vec<u8>> {
+        self.ensure_unlocked().await?;
+        let inner = {
+            let state = self.unlocked.lock().unwrap();
+            state
+                .inner
+                .clone()
+                .ok_or(KeyProviderError::Locked)?
+        };
+        inner.sign(message).await
+    }
+
+    fn public_key(&self) -> &PublicKeyData {
+        &self.public_data
+    }
+
+    fn label(&self) -> &str {
+        &self.label
+    }
+
+    fn supports_export(&self) -> bool {
+        true
+    }
+
+    async fn export_encrypted(&self, passphrase: &str) -> Result<EncryptedKeyExport> {
+        let seed = {
+            let state = self.unlocked.lock().unwrap();
+            state
+                .seed
+                .clone()
+                .ok_or(KeyProviderError::Locked)?
+        };
+        encrypt_seed(passphrase.as_bytes(), &seed, &self.label, self.algorithm)
+    }
+}
+
+/// Factory that creates and manages encrypted key files in a directory.
+///
+/// Each key is stored as `<dir>/<label>.key`. A metadata file `<dir>/<label>.pub`
+/// stores the public key so that `open()` can work without the passphrase.
+pub struct FileEncryptedProviderFactory {
+    dir: PathBuf,
+    auto_lock_timeout: Duration,
+}
+
+impl FileEncryptedProviderFactory {
+    pub fn new(dir: impl Into<PathBuf>, auto_lock_timeout: Duration) -> Self {
+        Self {
+            dir: dir.into(),
+            auto_lock_timeout,
+        }
+    }
+
+    /// Convenience constructor with a 5-minute auto-lock timeout.
+    pub fn with_dir(dir: impl Into<PathBuf>) -> Self {
+        Self::new(dir, Duration::from_secs(5 * 60))
+    }
+
+    fn key_path(&self, label: &str) -> PathBuf {
+        self.dir.join(format!("{label}.key"))
+    }
+
+    fn pub_path(&self, label: &str) -> PathBuf {
+        self.dir.join(format!("{label}.pub"))
+    }
+}
+
+#[async_trait]
+impl KeyProviderFactory for FileEncryptedProviderFactory {
+    async fn create(
+        &self,
+        label: &str,
+        algorithm: SignatureAlgorithm,
+    ) -> Result<Arc<dyn KeyProvider>> {
+        std::fs::create_dir_all(&self.dir)?;
+
+        let key_path = self.key_path(label);
+        if key_path.exists() {
+            return Err(KeyProviderError::AlreadyExists(label.into()));
+        }
+
+        let passphrase = read_passphrase("Enter passphrase for new key: ")?;
+
+        let provider = FileEncryptedProvider::create(
+            label,
+            key_path,
+            algorithm,
+            passphrase.as_bytes(),
+            self.auto_lock_timeout,
+        )?;
+
+        // Persist the public key separately so open() works without passphrase.
+        let pub_bytes = &provider.public_key().bytes;
+        std::fs::write(self.pub_path(label), pub_bytes)?;
+
+        Ok(Arc::new(provider))
+    }
+
+    async fn open(&self, label: &str) -> Result<Arc<dyn KeyProvider>> {
+        let key_path = self.key_path(label);
+        if !key_path.exists() {
+            return Err(KeyProviderError::NotFound(label.into()));
+        }
+
+        // Read public key from sidecar file.
+        let pub_path = self.pub_path(label);
+        let pub_bytes = std::fs::read(&pub_path).unwrap_or_default();
+        let export = read_key_file(&key_path)?;
+
+        let provider = FileEncryptedProvider::open(label, key_path, self.auto_lock_timeout)?;
+
+        // Patch in the real public key from sidecar.
+        let mut provider = provider;
+        if !pub_bytes.is_empty() {
+            provider.public_data = PublicKeyData::new(export.algorithm, pub_bytes);
+        }
+
+        // Prompt for passphrase on first open.
+        let passphrase = read_passphrase("Enter passphrase to unlock key: ")?;
+        provider.unlock(passphrase.as_bytes()).await?;
+
+        Ok(Arc::new(provider))
+    }
+
+    async fn list(&self) -> Result<Vec<String>> {
+        if !self.dir.exists() {
+            return Ok(vec![]);
+        }
+        let mut labels = vec![];
+        for entry in std::fs::read_dir(&self.dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("key") {
+                if let Some(name) = path.file_stem().and_then(|s| s.to_str()) {
+                    labels.push(name.to_string());
+                }
+            }
+        }
+        labels.sort();
+        Ok(labels)
+    }
+
+    async fn delete(&self, label: &str) -> Result<()> {
+        let key_path = self.key_path(label);
+        let pub_path = self.pub_path(label);
+        if key_path.exists() {
+            std::fs::remove_file(key_path)?;
+        }
+        if pub_path.exists() {
+            std::fs::remove_file(pub_path)?;
+        }
+        Ok(())
+    }
+}
+
+fn read_passphrase(_prompt: &str) -> Result<String> {
+    #[cfg(feature = "rpassword")]
+    {
+        rpassword::read_password()
+            .map_err(|e| KeyProviderError::AuthenticationFailed(format!("failed to read passphrase: {e}")))
+    }
+    #[cfg(not(feature = "rpassword"))]
+    {
+        let _ = prompt;
+        Err(KeyProviderError::UnsupportedOperation(
+            "enable 'rpassword' feature for interactive passphrase input".into(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn encrypted_file_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.key");
+        let passphrase = b"correct-horse-battery-staple";
+
+        let provider = FileEncryptedProvider::create(
+            "test",
+            path.clone(),
+            SignatureAlgorithm::Ed25519,
+            passphrase,
+            Duration::from_secs(300),
+        )
+        .unwrap();
+
+        let msg = b"hello encrypted world";
+        let sig = provider.sign(msg).await.unwrap();
+        assert_eq!(sig.len(), 64);
+
+        // Reopen and unlock
+        let reopened = FileEncryptedProvider::open("test", path, Duration::from_secs(300)).unwrap();
+        reopened.unlock(passphrase).await.unwrap();
+        let sig2 = reopened.sign(msg).await.unwrap();
+        assert_eq!(sig, sig2);
+    }
+
+    #[tokio::test]
+    async fn wrong_passphrase_fails() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.key");
+
+        FileEncryptedProvider::create(
+            "test",
+            path.clone(),
+            SignatureAlgorithm::Ed25519,
+            b"good-passphrase",
+            Duration::from_secs(300),
+        )
+        .unwrap();
+
+        let reopened = FileEncryptedProvider::open("test", path, Duration::from_secs(300)).unwrap();
+        let result = reopened.unlock(b"wrong-passphrase").await;
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn encrypt_decrypt_roundtrip() {
+        let seed = [42u8; 32];
+        let export = encrypt_seed(b"passphrase", &seed, "test", SignatureAlgorithm::Ed25519).unwrap();
+        let decrypted = decrypt_seed(b"passphrase", &export).unwrap();
+        assert_eq!(decrypted.as_slice(), seed);
+    }
+
+    #[test]
+    fn wrong_passphrase_decrypt_fails() {
+        let seed = [42u8; 32];
+        let export = encrypt_seed(b"passphrase", &seed, "test", SignatureAlgorithm::Ed25519).unwrap();
+        assert!(decrypt_seed(b"wrong", &export).is_err());
+    }
+}

--- a/keri_keyprovider/src/lib.rs
+++ b/keri_keyprovider/src/lib.rs
@@ -1,0 +1,143 @@
+//! # keri-keyprovider
+//!
+//! A standalone, decoupled cryptographic key provider interface.
+//!
+//! This crate defines the [`KeyProvider`] and [`KeyProviderFactory`] traits —
+//! abstracting over **any** signing backend: in-memory software keys, encrypted
+//! files, OS keystores, HSMs, cloud KMS services, or hardware secure enclaves.
+//!
+//! The traits are fully independent of the keriox stack and can be used by any
+//! Rust project that needs pluggable signing backends.
+
+mod error;
+mod types;
+
+pub use error::{KeyProviderError, Result};
+pub use types::{PublicKeyData, SignatureAlgorithm};
+
+use async_trait::async_trait;
+use std::sync::Arc;
+
+/// Core abstraction: anything that can sign a message.
+///
+/// Implementations range from in-memory software keys to remote HSMs and cloud
+/// KMS services. The private key material **never** needs to be exposed to the
+/// consumer — only the `sign()` operation and the public key.
+#[async_trait]
+pub trait KeyProvider: Send + Sync {
+    /// Sign a message and return raw signature bytes.
+    async fn sign(&self, message: &[u8]) -> Result<Vec<u8>>;
+
+    /// Return the public key for this provider.
+    fn public_key(&self) -> &PublicKeyData;
+
+    /// The signature algorithm this provider uses.
+    fn algorithm(&self) -> SignatureAlgorithm {
+        self.public_key().algorithm
+    }
+
+    /// Human-readable label for this key (e.g. alias, key ID, HSM slot).
+    fn label(&self) -> &str;
+
+    /// Whether this provider supports key rotation.
+    fn supports_rotation(&self) -> bool {
+        false
+    }
+
+    /// Rotate: replace the current key with a new one.
+    async fn rotate(
+        &mut self,
+        _new_next_public_key: PublicKeyData,
+    ) -> Result<()> {
+        Err(KeyProviderError::unsupported("rotate"))
+    }
+
+    /// Whether this provider can export encrypted key material.
+    fn supports_export(&self) -> bool {
+        false
+    }
+
+    /// Export the key material in encrypted form for backup/migration.
+    async fn export_encrypted(
+        &self,
+        _passphrase: &str,
+    ) -> Result<EncryptedKeyExport> {
+        Err(KeyProviderError::unsupported("export"))
+    }
+}
+
+/// Factory trait for creating and managing key providers.
+///
+/// A factory owns the lifecycle of key providers: creating new ones, opening
+/// existing ones, listing them, and deleting them.
+#[async_trait]
+pub trait KeyProviderFactory: Send + Sync {
+    /// Create a new random key provider with the given label and algorithm.
+    async fn create(
+        &self,
+        label: &str,
+        algorithm: SignatureAlgorithm,
+    ) -> Result<Arc<dyn KeyProvider>>;
+
+    /// Open an existing key provider by its label.
+    async fn open(&self, label: &str) -> Result<Arc<dyn KeyProvider>>;
+
+    /// List all labels managed by this factory.
+    async fn list(&self) -> Result<Vec<String>>;
+
+    /// Delete a key provider by label.
+    async fn delete(&self, label: &str) -> Result<()>;
+}
+
+/// Encrypted key export package for backup and cross-device migration.
+///
+/// The seed is encrypted with XChaCha20-Poly1305 using a key derived from
+/// the user's passphrase via Argon2id. This format is self-contained and
+/// can be serialized for storage or transfer.
+#[derive(Debug, Clone)]
+pub struct EncryptedKeyExport {
+    /// Format version (currently 1).
+    pub version: u8,
+    /// The label/alias of the key.
+    pub label: String,
+    /// The algorithm used by the key.
+    pub algorithm: SignatureAlgorithm,
+    /// Argon2id salt (32 bytes).
+    pub salt: Vec<u8>,
+    /// XChaCha20-Poly1305 nonce (24 bytes).
+    pub nonce: Vec<u8>,
+    /// Encrypted seed bytes (ciphertext + 16-byte Poly1305 tag).
+    pub ciphertext: Vec<u8>,
+    /// Argon2id parameters used for key derivation.
+    pub kdf_params: KdfParams,
+}
+
+/// Argon2id KDF parameters stored alongside the encrypted export.
+#[derive(Debug, Clone)]
+pub struct KdfParams {
+    /// Memory cost in KiB.
+    pub mem_cost: u32,
+    /// Number of iterations (time cost).
+    pub time_cost: u32,
+    /// Parallelism (number of lanes).
+    pub parallelism: u32,
+}
+
+impl Default for KdfParams {
+    fn default() -> Self {
+        Self {
+            mem_cost: 64 * 1024,
+            time_cost: 3,
+            parallelism: 1,
+        }
+    }
+}
+
+#[cfg(feature = "software")]
+pub mod software;
+
+#[cfg(feature = "file-encrypted")]
+pub mod file_encrypted;
+
+#[cfg(feature = "os-keychain")]
+pub mod os_keychain;

--- a/keri_keyprovider/src/os_keychain.rs
+++ b/keri_keyprovider/src/os_keychain.rs
@@ -1,0 +1,224 @@
+//! OS-native keychain provider.
+//!
+//! Stores encrypted seeds in the platform's native credential store:
+//! - **macOS**: Keychain Services
+//! - **Windows**: Credential Manager (DPAPI-encrypted)
+//! - **Linux**: Secret Service (GNOME Keyring / KDE Wallet) via DBus
+//!
+//! The key is unlocked by reading the seed from the OS keychain at runtime.
+//! On supported platforms, the OS may prompt for biometric or password unlock.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+
+use crate::{
+    software::SoftwareKeyProvider, KeyProvider, KeyProviderError, KeyProviderFactory, PublicKeyData,
+    Result, SignatureAlgorithm,
+};
+
+/// Persistent key provider backed by the OS-native keychain.
+///
+/// The seed is stored as a credential in the OS keychain. On unlock,
+/// the seed is read out and held in an `Arc<SoftwareKeyProvider>` in memory.
+/// The in-memory key is dropped (and zeroized by ed25519-dalek) on lock.
+pub struct OsKeychainProvider {
+    label: String,
+    service_name: String,
+    algorithm: SignatureAlgorithm,
+    public_data: PublicKeyData,
+    inner: Mutex<Option<Arc<SoftwareKeyProvider>>>,
+}
+
+impl OsKeychainProvider {
+    /// Create a new key in the OS keychain.
+    pub fn create(
+        label: impl Into<String>,
+        service_name: impl Into<String>,
+        algorithm: SignatureAlgorithm,
+    ) -> Result<Self> {
+        let label = label.into();
+        let service_name = service_name.into();
+
+        let provider = SoftwareKeyProvider::generate(&label, algorithm)?;
+        let public_data = provider.public_key().clone();
+
+        let seed = provider
+            .ed25519_seed_bytes()
+            .ok_or_else(|| {
+                KeyProviderError::UnsupportedAlgorithm("only Ed25519 supported".into())
+            })?;
+
+        let entry = keyring::Entry::new(&service_name, &label).map_err(|e| {
+            KeyProviderError::Other(format!("failed to create keychain entry: {e}"))
+        })?;
+        entry
+            .set_password(&hex_encode(&seed))
+            .map_err(|e| KeyProviderError::Other(format!("failed to write to keychain: {e}")))?;
+
+        Ok(Self {
+            label,
+            service_name,
+            algorithm,
+            public_data,
+            inner: Mutex::new(Some(Arc::new(provider))),
+        })
+    }
+
+    /// Open an existing key from the OS keychain (initially locked).
+    ///
+    /// Call `unlock()` to load the key material.
+    pub fn open(
+        label: impl Into<String>,
+        service_name: impl Into<String>,
+        algorithm: SignatureAlgorithm,
+        public_data: PublicKeyData,
+    ) -> Self {
+        Self {
+            label: label.into(),
+            service_name: service_name.into(),
+            algorithm,
+            public_data,
+            inner: Mutex::new(None),
+        }
+    }
+
+    /// Unlock by reading the seed from the OS keychain.
+    pub fn unlock(&self) -> Result<()> {
+        let entry = keyring::Entry::new(&self.service_name, &self.label).map_err(|e| {
+            KeyProviderError::Other(format!("failed to open keychain entry: {e}"))
+        })?;
+        let hex_seed = entry.get_password().map_err(|e| {
+            KeyProviderError::AuthenticationFailed(format!("failed to read from keychain: {e}"))
+        })?;
+
+        let seed_bytes = hex_to_bytes(&hex_seed)?;
+        let seed_arr: [u8; 32] = seed_bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| KeyProviderError::InvalidKeyMaterial("seed must be 32 bytes".into()))?;
+
+        let provider = SoftwareKeyProvider::from_ed25519_bytes(&self.label, &seed_arr)?;
+
+        let mut inner = self.inner.lock().unwrap();
+        *inner = Some(Arc::new(provider));
+
+        Ok(())
+    }
+
+    /// Lock the provider, dropping in-memory key material.
+    pub fn lock(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        *inner = None;
+    }
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn hex_to_bytes(hex: &str) -> Result<Vec<u8>> {
+    if hex.len() % 2 != 0 {
+        return Err(KeyProviderError::InvalidKeyMaterial("odd-length hex string".into()));
+    }
+    (0..hex.len())
+        .step_by(2)
+        .map(|i| {
+            u8::from_str_radix(&hex[i..i + 2], 16)
+                .map_err(|e| KeyProviderError::InvalidKeyMaterial(format!("invalid hex: {e}")))
+        })
+        .collect()
+}
+
+#[async_trait]
+impl KeyProvider for OsKeychainProvider {
+    async fn sign(&self, message: &[u8]) -> Result<Vec<u8>> {
+        let inner = {
+            let guard = self.inner.lock().unwrap();
+            guard.clone().ok_or(KeyProviderError::Locked)?
+        };
+        inner.sign(message).await
+    }
+
+    fn public_key(&self) -> &PublicKeyData {
+        &self.public_data
+    }
+
+    fn label(&self) -> &str {
+        &self.label
+    }
+
+    fn supports_export(&self) -> bool {
+        true
+    }
+}
+
+/// Factory that creates and manages keys in the OS keychain.
+pub struct OsKeychainProviderFactory {
+    service_name: String,
+}
+
+impl OsKeychainProviderFactory {
+    pub fn new(service_name: impl Into<String>) -> Self {
+        Self {
+            service_name: service_name.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl KeyProviderFactory for OsKeychainProviderFactory {
+    async fn create(
+        &self,
+        label: &str,
+        algorithm: SignatureAlgorithm,
+    ) -> Result<Arc<dyn KeyProvider>> {
+        let provider = OsKeychainProvider::create(label, &self.service_name, algorithm)?;
+        Ok(Arc::new(provider))
+    }
+
+    async fn open(&self, label: &str) -> Result<Arc<dyn KeyProvider>> {
+        let entry = keyring::Entry::new(&self.service_name, label).map_err(|e| {
+            KeyProviderError::Other(format!("failed to open keychain entry: {e}"))
+        })?;
+
+        let hex_seed = entry.get_password().map_err(|e| {
+            KeyProviderError::NotFound(format!("key '{label}' not found in keychain: {e}"))
+        })?;
+
+        let seed_bytes = hex_to_bytes(&hex_seed)?;
+        let seed_arr: [u8; 32] = seed_bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| KeyProviderError::InvalidKeyMaterial("seed must be 32 bytes".into()))?;
+
+        let provider = SoftwareKeyProvider::from_ed25519_bytes(label, &seed_arr)?;
+        let public_data = provider.public_key().clone();
+
+        let os_provider = OsKeychainProvider {
+            label: label.to_string(),
+            service_name: self.service_name.clone(),
+            algorithm: SignatureAlgorithm::Ed25519,
+            public_data,
+            inner: Mutex::new(Some(Arc::new(provider))),
+        };
+
+        Ok(Arc::new(os_provider))
+    }
+
+    async fn list(&self) -> Result<Vec<String>> {
+        Err(KeyProviderError::UnsupportedOperation(
+            "OS keychain does not support listing keys".into(),
+        ))
+    }
+
+    async fn delete(&self, label: &str) -> Result<()> {
+        let entry = keyring::Entry::new(&self.service_name, label).map_err(|e| {
+            KeyProviderError::Other(format!("failed to open keychain entry: {e}"))
+        })?;
+        entry.delete_credential().map_err(|e| {
+            KeyProviderError::Other(format!("failed to delete from keychain: {e}"))
+        })?;
+        Ok(())
+    }
+}

--- a/keri_keyprovider/src/software.rs
+++ b/keri_keyprovider/src/software.rs
@@ -1,0 +1,192 @@
+//! In-memory software key provider using ed25519-dalek and k256.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rand::rngs::OsRng;
+
+use crate::{
+    KeyProvider, KeyProviderError, KeyProviderFactory,
+    PublicKeyData, Result, SignatureAlgorithm,
+};
+
+/// In-memory Ed25519 or secp256k1 signing key.
+///
+/// Private key material lives only in RAM. The inner signing keys
+/// (`ed25519_dalek::SigningKey`, `k256::ecdsa::SigningKey`) handle their
+/// own cleanup when dropped. Public key bytes are not zeroized since they
+/// are not secret.
+pub struct SoftwareKeyProvider {
+    label: String,
+    inner: SoftwareKeyInner,
+    public_data: PublicKeyData,
+}
+
+enum SoftwareKeyInner {
+    Ed25519(ed25519_dalek::SigningKey),
+    #[allow(dead_code)]
+    Secp256k1(k256::ecdsa::SigningKey),
+}
+
+impl SoftwareKeyProvider {
+    pub fn generate(label: impl Into<String>, algorithm: SignatureAlgorithm) -> Result<Self> {
+        match algorithm {
+            SignatureAlgorithm::Ed25519 => {
+                let sk = ed25519_dalek::SigningKey::generate(&mut OsRng);
+                let pk_bytes = sk.verifying_key().to_bytes().to_vec();
+                Ok(Self {
+                    label: label.into(),
+                    inner: SoftwareKeyInner::Ed25519(sk),
+                    public_data: PublicKeyData::ed25519(pk_bytes),
+                })
+            }
+            SignatureAlgorithm::EcdsaSecp256k1 => {
+                let sk = k256::ecdsa::SigningKey::random(&mut OsRng);
+                let pk_bytes = sk.verifying_key().to_bytes().to_vec();
+                Ok(Self {
+                    label: label.into(),
+                    inner: SoftwareKeyInner::Secp256k1(sk),
+                    public_data: PublicKeyData::secp256k1(pk_bytes),
+                })
+            }
+        }
+    }
+
+    pub fn from_ed25519_bytes(label: impl Into<String>, seed: &[u8; 32]) -> Result<Self> {
+        let sk = ed25519_dalek::SigningKey::from_bytes(seed);
+        let pk_bytes = sk.verifying_key().to_bytes().to_vec();
+        Ok(Self {
+            label: label.into(),
+            inner: SoftwareKeyInner::Ed25519(sk),
+            public_data: PublicKeyData::ed25519(pk_bytes),
+        })
+    }
+
+    pub fn ed25519_seed_bytes(&self) -> Option<[u8; 32]> {
+        match &self.inner {
+            SoftwareKeyInner::Ed25519(sk) => Some(sk.to_bytes()),
+            SoftwareKeyInner::Secp256k1(_) => None,
+        }
+    }
+}
+
+#[async_trait]
+impl KeyProvider for SoftwareKeyProvider {
+    async fn sign(&self, message: &[u8]) -> Result<Vec<u8>> {
+        match &self.inner {
+            SoftwareKeyInner::Ed25519(sk) => {
+                use ed25519_dalek::Signer as _;
+                let sig: ed25519_dalek::Signature = sk.sign(message);
+                Ok(sig.to_bytes().to_vec())
+            }
+            SoftwareKeyInner::Secp256k1(sk) => {
+                use k256::ecdsa::signature::Signer as _;
+                let sig: k256::ecdsa::Signature = sk.sign(message);
+                Ok(sig.to_der().as_bytes().to_vec())
+            }
+        }
+    }
+
+    fn public_key(&self) -> &PublicKeyData {
+        &self.public_data
+    }
+
+    fn label(&self) -> &str {
+        &self.label
+    }
+
+    fn supports_rotation(&self) -> bool {
+        true
+    }
+
+    async fn rotate(&mut self, _new_next_public_key: PublicKeyData) -> Result<()> {
+        let new = Self::generate(self.label.clone(), self.algorithm())?;
+        // Safe: no Drop impl on Self, so moving fields is fine.
+        // The old inner value (with old private key) is dropped naturally.
+        self.inner = new.inner;
+        self.public_data = new.public_data;
+        Ok(())
+    }
+
+    fn supports_export(&self) -> bool {
+        true
+    }
+}
+
+/// Stateless factory that creates in-memory keys.
+///
+/// Since software keys are ephemeral, `open()` always returns `NotFound`.
+/// Use `FileEncryptedProviderFactory` or `OsKeychainProviderFactory` for
+/// persistent backends.
+pub struct SoftwareKeyProviderFactory;
+
+#[async_trait]
+impl KeyProviderFactory for SoftwareKeyProviderFactory {
+    async fn create(
+        &self,
+        label: &str,
+        algorithm: SignatureAlgorithm,
+    ) -> Result<Arc<dyn KeyProvider>> {
+        Ok(Arc::new(SoftwareKeyProvider::generate(label, algorithm)?))
+    }
+
+    async fn open(&self, label: &str) -> Result<Arc<dyn KeyProvider>> {
+        Err(KeyProviderError::NotFound(format!(
+            "software provider is stateless; key '{label}' was not created in this session"
+        )))
+    }
+
+    async fn list(&self) -> Result<Vec<String>> {
+        Ok(vec![])
+    }
+
+    async fn delete(&self, _label: &str) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::Verifier;
+
+    #[tokio::test]
+    async fn ed25519_sign_verify_roundtrip() {
+        let provider = SoftwareKeyProvider::generate("test", SignatureAlgorithm::Ed25519).unwrap();
+        let msg = b"hello keri";
+        let sig = provider.sign(msg).await.unwrap();
+        assert_eq!(sig.len(), 64);
+
+        let pk_bytes = &provider.public_key().bytes;
+        let pk = ed25519_dalek::VerifyingKey::from_bytes(
+            pk_bytes.as_slice().try_into().unwrap(),
+        )
+        .unwrap();
+        let signature = ed25519_dalek::Signature::from_bytes(
+            sig.as_slice().try_into().unwrap(),
+        );
+        assert!(pk.verify(msg, &signature).is_ok());
+    }
+
+    #[tokio::test]
+    async fn from_seed_reproduces_same_key() {
+        let seed = [42u8; 32];
+        let p1 = SoftwareKeyProvider::from_ed25519_bytes("a", &seed).unwrap();
+        let p2 = SoftwareKeyProvider::from_ed25519_bytes("b", &seed).unwrap();
+        assert_eq!(p1.public_key().bytes, p2.public_key().bytes);
+    }
+
+    #[tokio::test]
+    async fn factory_creates_unique_keys() {
+        let factory = SoftwareKeyProviderFactory;
+        let p1 = factory.create("a", SignatureAlgorithm::Ed25519).await.unwrap();
+        let p2 = factory.create("b", SignatureAlgorithm::Ed25519).await.unwrap();
+        assert_ne!(p1.public_key().bytes, p2.public_key().bytes);
+    }
+
+    #[tokio::test]
+    async fn factory_open_returns_not_found() {
+        let factory = SoftwareKeyProviderFactory;
+        assert!(factory.open("anything").await.is_err());
+    }
+}

--- a/keri_keyprovider/src/types.rs
+++ b/keri_keyprovider/src/types.rs
@@ -1,0 +1,31 @@
+/// Cryptographic signature algorithms supported by key providers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SignatureAlgorithm {
+    Ed25519,
+    EcdsaSecp256k1,
+}
+
+/// Raw public key data, algorithm-agnostic.
+///
+/// This is the provider-level representation of a public key, decoupled from
+/// any KERI-specific types. Higher layers (keriox_core adapter) convert this
+/// into the appropriate `BasicPrefix` / `PublicKey` types.
+#[derive(Debug, Clone)]
+pub struct PublicKeyData {
+    pub algorithm: SignatureAlgorithm,
+    pub bytes: Vec<u8>,
+}
+
+impl PublicKeyData {
+    pub fn new(algorithm: SignatureAlgorithm, bytes: Vec<u8>) -> Self {
+        Self { algorithm, bytes }
+    }
+
+    pub fn ed25519(bytes: Vec<u8>) -> Self {
+        Self::new(SignatureAlgorithm::Ed25519, bytes)
+    }
+
+    pub fn secp256k1(bytes: Vec<u8>) -> Self {
+        Self::new(SignatureAlgorithm::EcdsaSecp256k1, bytes)
+    }
+}

--- a/keriox_core/src/transport/default.rs
+++ b/keriox_core/src/transport/default.rs
@@ -73,10 +73,17 @@ where
             .await
             .map_err(|e| TransportError::NetworkError(e.to_string()))?;
         if !resp.status().is_success() {
+            let status = resp.status();
             let body = resp
                 .text()
                 .await
                 .map_err(|e| TransportError::NetworkError(e.to_string()))?;
+            if body.is_empty() {
+                return Err(TransportError::NetworkError(format!(
+                    "Remote returned {} with empty body",
+                    status
+                )));
+            }
             let err =
                 serde_json::from_str(&body).map_err(|_e| TransportError::UnknownError(body))?;
             return Err(TransportError::RemoteError(err));
@@ -119,6 +126,12 @@ where
                 Err(ResponseError::Unparsable(e)) => Err(TransportError::InvalidResponse(e)),
             }
         } else {
+            if body.is_empty() {
+                return Err(TransportError::NetworkError(format!(
+                    "Remote returned {} with empty body",
+                    status
+                )));
+            }
             let err =
                 serde_json::from_str(&body).map_err(|_| TransportError::UnknownError(body))?;
             Err(TransportError::RemoteError(err))
@@ -144,10 +157,17 @@ where
             let ops = parse_op_stream(&body)?;
             Ok(ops)
         } else {
+            let status = resp.status();
             let body = resp
                 .text()
                 .await
                 .map_err(|e| TransportError::NetworkError(e.to_string()))?;
+            if body.is_empty() {
+                return Err(TransportError::NetworkError(format!(
+                    "Remote returned {} with empty body",
+                    status
+                )));
+            }
             let err =
                 serde_json::from_str(&body).map_err(|_e| TransportError::UnknownError(body))?;
             Err(TransportError::RemoteError(err))
@@ -189,10 +209,17 @@ where
             let ops = body.to_vec();
             Ok(ops)
         } else {
+            let status = resp.status();
             let body = resp
                 .text()
                 .await
                 .map_err(|e| TransportError::NetworkError(e.to_string()))?;
+            if body.is_empty() {
+                return Err(TransportError::NetworkError(format!(
+                    "Remote returned {} with empty body",
+                    status
+                )));
+            }
             let err =
                 serde_json::from_str(&body).map_err(|_e| TransportError::UnknownError(body))?;
             Err(TransportError::RemoteError(err))
@@ -209,12 +236,19 @@ where
             .map_err(|e| TransportError::NetworkError(e.to_string()))?;
 
         if !resp.status().is_success() {
+            let status = resp.status();
             let body = resp
                 .text()
                 .await
                 .map_err(|e| TransportError::NetworkError(e.to_string()))?;
+            if body.is_empty() {
+                return Err(TransportError::NetworkError(format!(
+                    "Remote returned {} with empty body",
+                    status
+                )));
+            }
             let err = serde_json::from_str(&body)
-                .map_err(|e| TransportError::NetworkError(e.to_string()))?;
+                .map_err(|_| TransportError::UnknownError(body))?;
             return Err(TransportError::RemoteError(err));
         }
         Ok(())

--- a/keriox_core/src/transport/default.rs
+++ b/keriox_core/src/transport/default.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use serde::Deserialize;
 
 use super::{Transport, TransportError};
@@ -10,6 +12,14 @@ use crate::{
     prefix::IdentifierPrefix,
     query::query_event::SignedQueryMessage,
 };
+
+fn http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .expect("Failed to build HTTP client")
+}
 
 /// Default behavior for communication with other actors.
 /// Serializes a keri message, does a net request, and deserializes the response.
@@ -66,7 +76,7 @@ where
             },
             Scheme::Tcp => todo!(),
         };
-        let resp = reqwest::Client::new()
+        let resp = http_client()
             .post(url)
             .body(msg.to_cesr().unwrap())
             .send()
@@ -108,7 +118,7 @@ where
         };
 
         let op: Message = qry.into();
-        let resp = reqwest::Client::new()
+        let resp = http_client()
             .post(url)
             .body(op.to_cesr().unwrap())
             .send()
@@ -146,7 +156,9 @@ where
             .unwrap()
             .join(&loc.eid.to_string())
             .unwrap();
-        let resp = reqwest::get(url)
+        let resp = http_client()
+            .get(url)
+            .send()
             .await
             .map_err(|e| TransportError::NetworkError(e.to_string()))?;
         if resp.status().is_success() {
@@ -197,7 +209,9 @@ where
             .unwrap()
             .join(&eid.to_string())
             .unwrap();
-        let resp = reqwest::get(url)
+        let resp = http_client()
+            .get(url)
+            .send()
             .await
             .map_err(|e| TransportError::NetworkError(e.to_string()))?;
         if resp.status().is_success() {
@@ -227,8 +241,7 @@ where
     }
 
     async fn resolve_oobi(&self, loc: LocationScheme, oobi: Oobi) -> Result<(), TransportError<E>> {
-        let client = reqwest::Client::new();
-        let resp = client
+        let resp = http_client()
             .post(format!("{}resolve", loc.url))
             .body(serde_json::to_string(&oobi).unwrap())
             .send()

--- a/keriox_sdk/Cargo.toml
+++ b/keriox_sdk/Cargo.toml
@@ -21,6 +21,13 @@ rand = "0.8.5"
 ed25519-dalek = { version = "2.1.0", features = ["rand_core"] }
 base64 = "0.13"
 
+keri-keyprovider = { path = "../keri_keyprovider", version = "0.1.0", optional = true, features = ["software"] }
+tokio = { version = "1", features = ["full"], optional = true }
+
+[features]
+default = []
+keyprovider = ["keri-keyprovider", "tokio"]
+
 [dev-dependencies]
 keri-core = { path = "../keriox_core", version = "0.17.13" }
 tempfile = { version = "3.20" }

--- a/keriox_sdk/src/controller.rs
+++ b/keriox_sdk/src/controller.rs
@@ -78,4 +78,24 @@ impl Controller {
     pub fn find_state(&self, id: &IdentifierPrefix) -> Result<IdentifierState> {
         Ok(self.inner.find_state(id)?)
     }
+
+    /// Reconstruct an `Identifier` from a known prefix and optional registry.
+    ///
+    /// Use this to load an identifier whose database already exists at the
+    /// controller's `db_path`.
+    pub fn load_identifier(
+        &self,
+        id: IdentifierPrefix,
+        registry_id: Option<IdentifierPrefix>,
+    ) -> Identifier {
+        use keri_controller::controller::RedbIdentifier;
+        Identifier {
+            inner: RedbIdentifier::new(
+                id,
+                registry_id,
+                self.inner.known_events.clone(),
+                self.inner.communication.clone(),
+            ),
+        }
+    }
 }

--- a/keriox_sdk/src/error.rs
+++ b/keriox_sdk/src/error.rs
@@ -84,6 +84,14 @@ pub enum Error {
     #[error("delegation error: {0}")]
     DelegationError(String),
 
+    /// No pending multisig request was found in the mailbox.
+    #[error("no multisig request found")]
+    NoMultisigRequest,
+
+    /// A multisig-specific error.
+    #[error("multisig error: {0}")]
+    MultisigError(String),
+
     /// A catch-all for errors that do not fit a more specific variant.
     #[error("{0}")]
     Other(String),

--- a/keriox_sdk/src/error.rs
+++ b/keriox_sdk/src/error.rs
@@ -76,6 +76,14 @@ pub enum Error {
         reason: String,
     },
 
+    /// No pending delegation request was found in the mailbox.
+    #[error("no delegation request found")]
+    NoDelegationRequest,
+
+    /// A delegation-specific error.
+    #[error("delegation error: {0}")]
+    DelegationError(String),
+
     /// A catch-all for errors that do not fit a more specific variant.
     #[error("{0}")]
     Other(String),

--- a/keriox_sdk/src/error.rs
+++ b/keriox_sdk/src/error.rs
@@ -92,6 +92,11 @@ pub enum Error {
     #[error("multisig error: {0}")]
     MultisigError(String),
 
+    /// The delegator's key event log is not available locally.
+    /// Resolve the delegator's OOBI before calling `complete_delegation`.
+    #[error("delegator KEL not available locally for {0}; resolve the delegator's OOBI first")]
+    DelegatorKelNotAvailable(IdentifierPrefix),
+
     /// A catch-all for errors that do not fit a more specific variant.
     #[error("{0}")]
     Other(String),

--- a/keriox_sdk/src/identifier.rs
+++ b/keriox_sdk/src/identifier.rs
@@ -28,6 +28,8 @@ use crate::error::Result;
 pub use keri_controller::identifier::query::WatcherResponseError;
 pub use keri_controller::mailbox_updating::ActionRequired;
 
+use keri_core::prefix::IndexedSignature;
+
 /// Concrete identifier wrapping `keri_controller::controller::RedbIdentifier`.
 pub struct Identifier {
     pub(crate) inner: keri_controller::RedbIdentifier,
@@ -308,6 +310,89 @@ impl Identifier {
         watcher: IdentifierPrefix,
     ) -> Result<QueryEvent> {
         Ok(self.inner.query_full_log(id, watcher)?)
+    }
+
+    // ── Delegation / group ────────────────────────────────────────────────────
+
+    /// Generate a delegated (or group) inception event and exchange messages.
+    ///
+    /// If `delegator` is provided, a DIP (delegated inception) is created and
+    /// a delegation-request exchange is appended to the returned list.
+    /// Returns `(serialized_event, vec_of_serialized_exchanges)`.
+    pub fn incept_group(
+        &self,
+        participants: Vec<IdentifierPrefix>,
+        signature_threshold: u64,
+        next_keys_threshold: Option<u64>,
+        initial_witnesses: Option<Vec<BasicPrefix>>,
+        witness_threshold: Option<u64>,
+        delegator: Option<IdentifierPrefix>,
+    ) -> Result<(String, Vec<String>)> {
+        Ok(self.inner.incept_group(
+            participants,
+            signature_threshold,
+            next_keys_threshold,
+            initial_witnesses,
+            witness_threshold,
+            delegator,
+        )?)
+    }
+
+    /// Finalise a group/delegated inception event. Returns the new prefix.
+    pub async fn finalize_group_incept(
+        &mut self,
+        group_event: &[u8],
+        sig: SelfSigningPrefix,
+        exchanges: Vec<(Vec<u8>, Signature)>,
+    ) -> Result<IdentifierPrefix> {
+        Ok(self
+            .inner
+            .finalize_group_incept(group_event, sig, exchanges)
+            .await?)
+    }
+
+    /// Finalise a group event (e.g. a delegating IXN).
+    pub async fn finalize_group_event(
+        &mut self,
+        group_event: &[u8],
+        sig: SelfSigningPrefix,
+        exchanges: Vec<(Vec<u8>, Signature)>,
+    ) -> Result<()> {
+        Ok(self
+            .inner
+            .finalize_group_event(group_event, sig, exchanges)
+            .await?)
+    }
+
+    /// Finalise an exchange message (e.g. delegation approval forwarding).
+    pub async fn finalize_exchange(
+        &self,
+        exchange: &[u8],
+        exn_signature: Signature,
+        data_signature: IndexedSignature,
+    ) -> Result<()> {
+        Ok(self
+            .inner
+            .finalize_exchange(exchange, exn_signature, data_signature)
+            .await?)
+    }
+
+    /// Create a transferable signature at a specific key index.
+    pub fn sign_with_index(
+        &self,
+        signature: SelfSigningPrefix,
+        key_index: u16,
+    ) -> Result<Signature> {
+        Ok(self.inner.sign_with_index(signature, key_index)?)
+    }
+
+    /// Save an external notice (e.g. a delegator's KEL event) into the local DB.
+    pub fn save_notice(&self, notice: &Notice) -> Result<()> {
+        use keri_core::event_message::signed_event_message::Message;
+        self.inner
+            .known_events
+            .save(&Message::Notice(notice.clone()))?;
+        Ok(())
     }
 
     // ── Low-level seal helpers ───────────────────────────────────────────────

--- a/keriox_sdk/src/identifier.rs
+++ b/keriox_sdk/src/identifier.rs
@@ -395,6 +395,36 @@ impl Identifier {
         Ok(())
     }
 
+    // ── OOBI location helpers ──────────────────────────────────────────────
+
+    /// Get known location schemes for an identifier.
+    pub fn get_location(
+        &self,
+        id: &IdentifierPrefix,
+    ) -> Result<Vec<LocationScheme>> {
+        self.inner
+            .get_location(id)
+            .map_err(|e| crate::error::Error::Other(e.to_string()))
+    }
+
+    /// Get location schemes for identifiers serving a specific role for `id`.
+    pub fn get_role_location(
+        &self,
+        id: &IdentifierPrefix,
+        role: keri_core::oobi::Role,
+    ) -> Result<Vec<LocationScheme>> {
+        Ok(self.inner.get_role_location(id, role)?)
+    }
+
+    /// Get end-role entries for an identifier and role.
+    pub fn get_end_role(
+        &self,
+        id: &IdentifierPrefix,
+        role: keri_core::oobi::Role,
+    ) -> Result<Vec<keri_controller::EndRole>> {
+        Ok(self.inner.get_end_role(id, role)?)
+    }
+
     // ── Low-level seal helpers ───────────────────────────────────────────────
 
     pub fn get_last_establishment_event_seal(&self) -> Result<EventSeal> {

--- a/keriox_sdk/src/keyprovider_adapter.rs
+++ b/keriox_sdk/src/keyprovider_adapter.rs
@@ -1,0 +1,84 @@
+//! Adapter bridging [`keri_keyprovider::KeyProvider`] to the keriox signing interface.
+//!
+//! This module is only available when the `keyprovider` feature is enabled.
+//!
+//! [`KeriSigner`] wraps either a traditional [`Signer`] or a pluggable
+//! [`KeyProvider`] and exposes a uniform sync `sign()` / `public_key()` API
+//! that all SDK operations can use.
+
+use std::sync::Arc;
+
+use keri_core::{keys::PublicKey, signer::Signer};
+use keri_controller::BasicPrefix;
+
+use crate::error::Error;
+
+/// Unified signer that works with either a legacy [`Signer`] or a
+/// pluggable [`KeyProvider`](keri_keyprovider::KeyProvider).
+///
+/// Construct via the `From` implementations or the convenience constructors.
+/// All SDK operations that previously took `Arc<Signer>` can now take `KeriSigner`.
+#[derive(Clone)]
+pub enum KeriSigner {
+    /// Legacy in-memory signer (keriox_core::Signer).
+    Legacy(Arc<Signer>),
+    /// Pluggable key provider (keri_keyprovider::KeyProvider).
+    Provider(Arc<dyn keri_keyprovider::KeyProvider>),
+}
+
+impl KeriSigner {
+    /// Sign a message, returning raw Ed25519 signature bytes.
+    ///
+    /// For the `Legacy` variant this delegates to [`Signer::sign()`].
+    /// For the `Provider` variant it blocks on the async
+    /// [`KeyProvider::sign()`](keri_keyprovider::KeyProvider::sign) call
+    /// (the call is CPU-bound and completes immediately for software keys).
+    pub fn sign(&self, msg: &[u8]) -> crate::Result<Vec<u8>> {
+        match self {
+            KeriSigner::Legacy(s) => s
+                .sign(msg)
+                .map_err(|e| Error::Signing(e.to_string())),
+            KeriSigner::Provider(p) => {
+                let msg = msg.to_vec();
+                tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(async {
+                        p.sign(&msg).await
+                    })
+                })
+                .map_err(|e| Error::Signing(e.to_string()))
+            }
+        }
+    }
+
+    /// Return the public key as a keriox [`PublicKey`].
+    pub fn public_key(&self) -> PublicKey {
+        match self {
+            KeriSigner::Legacy(s) => s.public_key(),
+            KeriSigner::Provider(p) => {
+                PublicKey::new(p.public_key().bytes.clone())
+            }
+        }
+    }
+
+    /// Return the [`BasicPrefix::Ed25519`] for this key (transferable).
+    pub fn basic_prefix(&self) -> BasicPrefix {
+        BasicPrefix::Ed25519(self.public_key())
+    }
+
+    /// Return the [`BasicPrefix::Ed25519NT`] for this key (non-transferable).
+    pub fn basic_prefix_nt(&self) -> BasicPrefix {
+        BasicPrefix::Ed25519NT(self.public_key())
+    }
+}
+
+impl From<Arc<Signer>> for KeriSigner {
+    fn from(signer: Arc<Signer>) -> Self {
+        KeriSigner::Legacy(signer)
+    }
+}
+
+impl From<Arc<dyn keri_keyprovider::KeyProvider>> for KeriSigner {
+    fn from(provider: Arc<dyn keri_keyprovider::KeyProvider>) -> Self {
+        KeriSigner::Provider(provider)
+    }
+}

--- a/keriox_sdk/src/lib.rs
+++ b/keriox_sdk/src/lib.rs
@@ -88,7 +88,8 @@ pub use error::{Error, Result};
 pub use identifier::Identifier;
 pub use identifier::{ActionRequired, WatcherResponseError};
 pub use types::{
-    CredentialStatus, IdentifierConfig, RotationConfig, SignedEnvelope, VerifiedPayload,
+    CredentialStatus, DelegationConfig, DelegationRequest, IdentifierConfig, RotationConfig,
+    SignedEnvelope, VerifiedPayload,
 };
 pub use store::KeriStore;
 pub use tel::{check_credential_status, get_credential_status};
@@ -106,6 +107,7 @@ pub use keri_core::{
     actor::prelude::SelfAddressingIdentifier,
     event::sections::seal::EventSeal,
     event_message::signature::Signature,
+    prefix::IndexedSignature,
     signer::Signer,
 };
 

--- a/keriox_sdk/src/lib.rs
+++ b/keriox_sdk/src/lib.rs
@@ -117,3 +117,8 @@ pub use teliox::query::TelQueryEvent;
 
 // Watcher/mailbox query types (kept for consumers that need low-level access)
 pub use keri_core::query::query_event::QueryEvent;
+// Re-export underlying crates for advanced consumers that need low-level access
+pub use keri_core;
+pub use keri_controller;
+pub use cesrox;
+pub use said;

--- a/keriox_sdk/src/lib.rs
+++ b/keriox_sdk/src/lib.rs
@@ -88,8 +88,8 @@ pub use error::{Error, Result};
 pub use identifier::Identifier;
 pub use identifier::{ActionRequired, WatcherResponseError};
 pub use types::{
-    CredentialStatus, DelegationConfig, DelegationRequest, IdentifierConfig, RotationConfig,
-    SignedEnvelope, VerifiedPayload,
+    CredentialStatus, DelegationConfig, DelegationRequest, GroupConfig, IdentifierConfig,
+    MultisigRequest, RotationConfig, SignedEnvelope, VerifiedPayload,
 };
 pub use store::KeriStore;
 pub use tel::{check_credential_status, get_credential_status};

--- a/keriox_sdk/src/lib.rs
+++ b/keriox_sdk/src/lib.rs
@@ -91,8 +91,8 @@ pub use error::{Error, Result};
 pub use identifier::Identifier;
 pub use identifier::{ActionRequired, WatcherResponseError};
 pub use types::{
-    CredentialStatus, DelegationConfig, DelegationRequest, GroupConfig, IdentifierConfig,
-    MultisigRequest, RotationConfig, SignedEnvelope, VerifiedPayload,
+    CredentialStatus, DelegationConfig, DelegationRequest, IdentifierConfig, MultisigConfig,
+    MultisigRequest, PendingRequest, RotationConfig, SignedEnvelope, VerifiedPayload,
 };
 pub use store::KeriStore;
 pub use tel::{check_credential_status, get_credential_status};

--- a/keriox_sdk/src/lib.rs
+++ b/keriox_sdk/src/lib.rs
@@ -83,6 +83,9 @@ pub mod store;
 pub mod tel;
 pub mod types;
 
+#[cfg(feature = "keyprovider")]
+pub mod keyprovider_adapter;
+
 pub use controller::Controller;
 pub use error::{Error, Result};
 pub use identifier::Identifier;

--- a/keriox_sdk/src/operations.rs
+++ b/keriox_sdk/src/operations.rs
@@ -22,15 +22,14 @@ use keri_core::{
     query::mailbox::SignedMailboxQuery,
 };
 
-use keri_core::event_message::signed_event_message::Notice;
 
 use crate::{
     controller::Controller,
     error::{Error, Result},
     identifier::{Identifier, ActionRequired},
     types::{
-        DelegationConfig, DelegationRequest, GroupConfig, IdentifierConfig, MultisigRequest,
-        RotationConfig,
+        DelegationConfig, DelegationRequest, IdentifierConfig, MultisigConfig, MultisigRequest,
+        PendingRequest, RotationConfig,
     },
 };
 
@@ -152,49 +151,6 @@ pub async fn create_identifier<S: SigningBackend + Clone + 'static>(
     Ok(id)
 }
 
-/// Create a new identifier (deprecated alias for [`create_identifier`]).
-///
-/// # Deprecated
-/// Use [`create_identifier`] with an [`IdentifierConfig`] instead.
-#[deprecated(since = "0.2.0", note = "use create_identifier with IdentifierConfig")]
-pub async fn setup_identifier<S: SigningBackend + Clone + 'static>(
-    controller: &Controller,
-    signer: S,
-    next_pk: BasicPrefix,
-    witnesses: Vec<LocationScheme>,
-    witness_threshold: u64,
-    watchers: Vec<LocationScheme>,
-) -> Result<Identifier> {
-    let pks = vec![BasicPrefix::Ed25519(signer.public_key())];
-    let npks = vec![next_pk];
-
-    let inception_event = controller
-        .incept(pks, npks, witnesses.clone(), witness_threshold)
-        .await?;
-
-    let sig = ed25519_sig(&signer, inception_event.as_bytes())?;
-    let mut id = controller.finalize_incept(inception_event.as_bytes(), &sig)?;
-
-    id.notify_witnesses().await?;
-
-    for wit in &witnesses {
-        if let IdentifierPrefix::Basic(wit_id) = &wit.eid {
-            _query_mailbox(&mut id, &signer, wit_id).await?;
-        }
-        id.send_oobi_to_watcher(id.id(), &Oobi::Location(wit.clone()))
-            .await?;
-        if let IdentifierPrefix::Basic(wit_id) = &wit.eid {
-            _query_mailbox(&mut id, &signer, wit_id).await?;
-        }
-    }
-
-    for watch in &watchers {
-        add_watcher(&mut id, &signer, watch).await?;
-    }
-
-    Ok(id)
-}
-
 /// Add and configure a watcher for an identifier.
 ///
 /// Resolves the watcher's OOBI, generates an `end_role_add` reply, signs it,
@@ -240,45 +196,6 @@ pub async fn rotate<S: SigningBackend + Clone + 'static>(
             config.witness_to_add,
             config.witness_to_remove,
             config.witness_threshold,
-        )
-        .await?;
-
-    let sig = ed25519_sig(&current_signer, rotation_event.as_bytes())?;
-    id.finalize_rotate(rotation_event.as_bytes(), sig).await?;
-    id.notify_witnesses().await?;
-
-    let witnesses = id.find_state(id.id())?.witness_config.witnesses;
-    for witness in witnesses {
-        _query_mailbox(id, &current_signer, &witness).await?;
-    }
-
-    Ok(())
-}
-
-/// Rotation with explicit positional args (deprecated alias for [`rotate`]).
-///
-/// # Deprecated
-/// Use [`rotate`] with a [`RotationConfig`] instead.
-#[deprecated(since = "0.2.0", note = "use rotate with RotationConfig")]
-pub async fn rotate_identifier<S: SigningBackend + Clone + 'static>(
-    id: &mut Identifier,
-    current_signer: S,
-    new_next_keys: Vec<BasicPrefix>,
-    new_next_threshold: u64,
-    witness_to_add: Vec<LocationScheme>,
-    witness_to_remove: Vec<BasicPrefix>,
-    witness_threshold: u64,
-) -> Result<()> {
-    let current_keys = vec![BasicPrefix::Ed25519NT(current_signer.public_key())];
-
-    let rotation_event = id
-        .rotate(
-            current_keys,
-            new_next_keys,
-            new_next_threshold,
-            witness_to_add,
-            witness_to_remove,
-            witness_threshold,
         )
         .await?;
 
@@ -361,19 +278,6 @@ pub async fn issue<S: SigningBackend + Clone + 'static>(
     Ok(())
 }
 
-/// Issue a credential — deprecated positional-arg alias for [`issue`].
-///
-/// # Deprecated
-/// Use [`issue`] instead.
-#[deprecated(since = "0.2.0", note = "use issue(id, signer, cred_said)")]
-pub async fn issue_credential<S: SigningBackend + Clone + 'static>(
-    identifier: &mut Identifier,
-    cred_said: SelfAddressingIdentifier,
-    km: S,
-) -> Result<()> {
-    issue(identifier, km, cred_said).await
-}
-
 /// Revoke a credential (TEL `rev` + anchor `ixn` + witness/backer notification).
 ///
 /// After this call the credential identified by `credential_said` is in the
@@ -404,19 +308,6 @@ pub async fn revoke<S: SigningBackend + Clone + 'static>(
     id.notify_backers().await?;
 
     Ok(())
-}
-
-/// Revoke a credential — deprecated positional-arg alias for [`revoke`].
-///
-/// # Deprecated
-/// Use [`revoke`] instead.
-#[deprecated(since = "0.2.0", note = "use revoke(id, signer, cred_said)")]
-pub async fn revoke_credential<S: SigningBackend + Clone + 'static>(
-    identifier: &mut Identifier,
-    cred_said: &SelfAddressingIdentifier,
-    km: S,
-) -> Result<()> {
-    revoke(identifier, km, cred_said).await
 }
 
 /// Sign and send mailbox queries to a single witness; return the signed queries.
@@ -478,80 +369,6 @@ async fn _query_mailbox_for<S: SigningBackend>(
 
 // ── Delegation operations ────────────────────────────────────────────────────
 
-/// Create a delegated identifier (delegatee side, step 1 of 2).
-///
-/// Internally creates a temporary helper identifier, generates a DIP
-/// (delegated inception) event, signs it, and sends the delegation request
-/// to the delegator via witnesses.
-///
-/// The delegated identifier is **not** yet accepted — the delegator must
-/// approve it first. After approval, call [`finalize_delegation`] with
-/// the returned `Identifier` and prefix.
-///
-/// Returns `(temporary_identifier, delegated_prefix)`.
-///
-/// # Errors
-/// - [`Error::Controller`] on event generation failures.
-/// - [`Error::Mechanics`] on network failures.
-/// - [`Error::Signing`] if signing fails.
-pub async fn create_delegated_identifier<S: SigningBackend + Clone + 'static>(
-    db_path: PathBuf,
-    signer: S,
-    next_pk: BasicPrefix,
-    config: DelegationConfig,
-) -> Result<(Identifier, IdentifierPrefix)> {
-    // Step 1: Create a temporary identifier (needed by incept_group).
-    let temp_config = IdentifierConfig {
-        witnesses: config.witnesses.clone(),
-        witness_threshold: config.witness_threshold,
-        watchers: vec![], // watchers configured after delegation is accepted
-    };
-    let mut temp_id = create_identifier(db_path, signer.clone(), next_pk, temp_config).await?;
-
-    // Step 2: Extract witness BasicPrefixes for the delegated identifier.
-    let witness_ids: Vec<BasicPrefix> = config
-        .witnesses
-        .iter()
-        .filter_map(|w| {
-            if let IdentifierPrefix::Basic(b) = &w.eid {
-                Some(b.clone())
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    // Step 3: Generate delegated inception (DIP) + exchange messages.
-    let (dip, exn_messages) = temp_id.incept_group(
-        vec![],
-        1,
-        Some(1),
-        Some(witness_ids),
-        Some(config.witness_threshold),
-        Some(config.delegator),
-    )?;
-
-    // Step 4: Sign and finalise.
-    let sig_icp = ed25519_sig(&signer, dip.as_bytes())?;
-
-    // The last exchange message is the delegation request to the delegator.
-    let delegation_exn = exn_messages
-        .last()
-        .ok_or_else(|| Error::DelegationError("no exchange message generated".into()))?;
-    let sig_exn = ed25519_sig(&signer, delegation_exn.as_bytes())?;
-    let exn_index_sig = temp_id.sign_with_index(sig_exn, 0)?;
-
-    let delegated_prefix = temp_id
-        .finalize_group_incept(
-            dip.as_bytes(),
-            sig_icp,
-            vec![(delegation_exn.as_bytes().to_vec(), exn_index_sig)],
-        )
-        .await?;
-
-    Ok((temp_id, delegated_prefix))
-}
-
 /// Approve a pending delegation request (delegator side).
 ///
 /// Signs the delegating IXN event, notifies witnesses, queries the mailbox
@@ -603,68 +420,150 @@ pub async fn approve_delegation<S: SigningBackend + Clone + 'static>(
     Ok(())
 }
 
-/// Complete the delegation process after the delegator approves (delegatee
-/// side, step 2 of 2).
+// ── Multisig operations ──────────────────────────────────────────────────────
+
+/// Request a delegated identifier (delegatee side, step 1 of 2).
 ///
-/// Saves the delegator's KEL into the local database, then queries the
-/// delegated identifier's mailbox until the DIP event is accepted.
+/// Sends a delegation request to the delegator specified in `config`.
+/// The returned identifier is **not** yet accepted — the delegator must
+/// approve it first (see [`approve_delegation`]).
 ///
-/// `delegator_kel` is the delegator's KEL (inception + receipts) obtained
-/// out-of-band or via OOBI resolution.
+/// After approval, call [`complete_delegation`] with the returned values.
+///
+/// Returns `(identifier_handle, delegated_prefix)`.
 ///
 /// # Errors
+/// - [`Error::Controller`] on event generation failures.
+/// - [`Error::Mechanics`] on network failures.
+/// - [`Error::Signing`] if signing fails.
+pub async fn request_delegation<S: SigningBackend + Clone + 'static>(
+    db_path: PathBuf,
+    signer: S,
+    next_pk: BasicPrefix,
+    config: DelegationConfig,
+) -> Result<(Identifier, IdentifierPrefix)> {
+    // Create a temporary identifier (needed by incept_group).
+    let temp_config = IdentifierConfig {
+        witnesses: config.witnesses.clone(),
+        witness_threshold: config.witness_threshold,
+        watchers: vec![], // watchers configured after delegation is accepted
+    };
+    let mut temp_id = create_identifier(db_path, signer.clone(), next_pk, temp_config).await?;
+
+    // Extract witness BasicPrefixes for the delegated identifier.
+    let witness_ids: Vec<BasicPrefix> = config
+        .witnesses
+        .iter()
+        .filter_map(|w| {
+            if let IdentifierPrefix::Basic(b) = &w.eid {
+                Some(b.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // Generate delegated inception (DIP) + exchange messages.
+    let (dip, exn_messages) = temp_id.incept_group(
+        vec![],
+        1,
+        Some(1),
+        Some(witness_ids),
+        Some(config.witness_threshold),
+        Some(config.delegator),
+    )?;
+
+    // Sign and finalise.
+    let sig_icp = ed25519_sig(&signer, dip.as_bytes())?;
+
+    let delegation_exn = exn_messages
+        .last()
+        .ok_or_else(|| Error::DelegationError("no exchange message generated".into()))?;
+    let sig_exn = ed25519_sig(&signer, delegation_exn.as_bytes())?;
+    let exn_index_sig = temp_id.sign_with_index(sig_exn, 0)?;
+
+    let delegated_prefix = temp_id
+        .finalize_group_incept(
+            dip.as_bytes(),
+            sig_icp,
+            vec![(delegation_exn.as_bytes().to_vec(), exn_index_sig)],
+        )
+        .await?;
+
+    Ok((temp_id, delegated_prefix))
+}
+
+/// Complete the delegation after the delegator has approved (delegatee
+/// side, step 2 of 2).
+///
+/// Retrieves the delegator's key event log from the local database
+/// and queries the delegated identifier's mailbox to finalise acceptance.
+///
+/// # Preconditions
+/// The delegator's OOBI must have been resolved beforehand so that their
+/// key event log is available locally (e.g. via
+/// `identifier.resolve_oobi(&delegator_oobi)`).
+///
+/// # Errors
+/// - [`Error::DelegatorKelNotAvailable`] if the delegator's events are
+///   not in the local database. Resolve the delegator's OOBI first.
+/// - [`Error::NoWitnesses`] if the identifier has no witnesses configured.
 /// - [`Error::Mechanics`] on network or mailbox failures.
 /// - [`Error::Signing`] if signing fails.
-pub async fn finalize_delegation<S: SigningBackend + Clone + 'static>(
+pub async fn complete_delegation<S: SigningBackend + Clone + 'static>(
     temp_id: &mut Identifier,
     signer: &S,
     delegated_prefix: &IdentifierPrefix,
-    delegator_kel: Vec<Notice>,
-    witnesses: &[BasicPrefix],
+    delegator_id: &IdentifierPrefix,
 ) -> Result<()> {
-    // Save the delegator's KEL events into local DB.
+    // Get witnesses from identifier state.
+    let witnesses: Vec<BasicPrefix> = temp_id.witnesses().collect();
+    if witnesses.is_empty() {
+        return Err(Error::NoWitnesses(temp_id.id().clone()));
+    }
+
+    // Get delegator's KEL from local DB.
+    let delegator_kel = temp_id
+        .get_kel(delegator_id)
+        .ok_or_else(|| Error::DelegatorKelNotAvailable(delegator_id.clone()))?;
+
+    // Save the delegator's KEL notices into local DB.
     for notice in &delegator_kel {
         temp_id.save_notice(notice)?;
     }
 
-    // Query mailbox for the delegated identifier to get the delegating event.
-    for witness in witnesses {
+    // Query mailbox for the delegated identifier (two rounds).
+    for witness in &witnesses {
         _query_mailbox_for(temp_id, signer, delegated_prefix, witness).await?;
     }
-
-    // Query again to get witness receipts (the DIP may now be accepted).
-    for witness in witnesses {
+    for witness in &witnesses {
         _query_mailbox_for(temp_id, signer, delegated_prefix, witness).await?;
     }
 
     Ok(())
 }
 
-// ── Multisig operations ──────────────────────────────────────────────────────
-
-/// Create a multisig group identifier (initiator side).
+/// Create a multisig identifier (initiator side).
 ///
-/// Generates the group inception event, signs it with the caller's key,
-/// and sends exchange messages to all other participants via witnesses.
+/// Generates the group inception event, signs it, and sends invitations
+/// to all other members via witnesses. The identifier is **not** yet
+/// accepted — other members must co-sign via [`accept_multisig`], and
+/// all members must call [`sync_multisig`] to finalise.
 ///
-/// The group identifier is **not** yet accepted — other participants must
-/// co-sign via [`join_group`], and all participants must call
-/// [`collect_group_signatures`] to finalise.
-///
-/// Returns the group `IdentifierPrefix`.
+/// Returns the multisig `IdentifierPrefix`.
 ///
 /// # Preconditions
 /// - `id` must be a fully established individual identifier with witnesses.
-/// - The caller must have resolved all participants' KELs (via watcher/OOBI).
+/// - The caller must have resolved all members' OOBIs.
 ///
 /// # Errors
-/// - [`Error::Controller`] if group inception generation fails.
+/// - [`Error::Controller`] if event generation fails.
 /// - [`Error::Mechanics`] on network failures.
 /// - [`Error::Signing`] if signing fails.
-pub async fn create_group_identifier<S: SigningBackend + Clone + 'static>(
+pub async fn create_multisig<S: SigningBackend + Clone + 'static>(
     id: &mut Identifier,
     signer: &S,
-    config: GroupConfig,
+    config: MultisigConfig,
 ) -> Result<IdentifierPrefix> {
     let witness_ids: Vec<BasicPrefix> = config
         .witnesses
@@ -679,9 +578,9 @@ pub async fn create_group_identifier<S: SigningBackend + Clone + 'static>(
         .collect();
 
     let (icp, exn_messages) = id.incept_group(
-        config.participants,
-        config.signature_threshold,
-        config.next_keys_threshold,
+        config.members,
+        config.threshold,
+        Some(config.threshold),
         Some(witness_ids),
         Some(config.witness_threshold),
         config.delegator,
@@ -689,7 +588,6 @@ pub async fn create_group_identifier<S: SigningBackend + Clone + 'static>(
 
     let sig_icp = ed25519_sig(signer, icp.as_bytes())?;
 
-    // Sign each exchange message (one per participant, plus optional delegation).
     let mut exchange_pairs = Vec::with_capacity(exn_messages.len());
     for exn in &exn_messages {
         let sig_exn = ed25519_sig(signer, exn.as_bytes())?;
@@ -704,17 +602,19 @@ pub async fn create_group_identifier<S: SigningBackend + Clone + 'static>(
     Ok(group_prefix)
 }
 
-/// Co-sign a multisig group event discovered in the mailbox (joiner side).
+/// Accept a multisig invitation discovered in the mailbox (joiner side).
 ///
-/// The `request` is obtained by calling [`query_multisig_requests`] or by
-/// converting an [`ActionRequired::MultisigRequest`] into a
-/// [`MultisigRequest`].
+/// Co-signs the group event and forwards the signature to other members
+/// via witnesses.
+///
+/// The `request` is obtained from [`poll_pending_requests`] or by
+/// converting an `ActionRequired::MultisigRequest`.
 ///
 /// # Errors
 /// - [`Error::EncodingError`] if event encoding fails.
 /// - [`Error::Mechanics`] on network failures.
 /// - [`Error::Signing`] if signing fails.
-pub async fn join_group<S: SigningBackend + Clone + 'static>(
+pub async fn accept_multisig<S: SigningBackend + Clone + 'static>(
     id: &mut Identifier,
     signer: &S,
     request: MultisigRequest,
@@ -742,58 +642,68 @@ pub async fn join_group<S: SigningBackend + Clone + 'static>(
     Ok(())
 }
 
-/// Collect co-signatures and witness receipts for a group event.
+/// Synchronise the multisig identifier state.
 ///
-/// Queries the group identifier's mailbox in two rounds (matching the
-/// protocol requirement for signature collection followed by receipt
-/// collection). Must be called by **all** participants after the group
-/// event has been co-signed by enough participants.
+/// Queries the multisig identifier's mailbox to collect co-signatures
+/// from other members and witness receipts. Must be called by **all**
+/// members after enough co-signatures have been submitted.
 ///
 /// After this call, verify acceptance with
-/// `id.find_state(group_id)`.
+/// `id.find_state(multisig_id)`.
 ///
 /// # Errors
+/// - [`Error::NoWitnesses`] if the identifier has no witnesses configured.
 /// - [`Error::Mechanics`] on network or mailbox failures.
 /// - [`Error::Signing`] if signing fails.
-pub async fn collect_group_signatures<S: SigningBackend + Clone + 'static>(
+pub async fn sync_multisig<S: SigningBackend + Clone + 'static>(
     id: &mut Identifier,
     signer: &S,
-    group_id: &IdentifierPrefix,
-    witnesses: &[BasicPrefix],
+    multisig_id: &IdentifierPrefix,
 ) -> Result<()> {
-    // Round 1: collect co-signatures from other participants.
-    for witness in witnesses {
-        _query_mailbox_for(id, signer, group_id, witness).await?;
+    let witnesses: Vec<BasicPrefix> = id.witnesses().collect();
+    if witnesses.is_empty() {
+        return Err(Error::NoWitnesses(id.id().clone()));
+    }
+
+    // Round 1: collect co-signatures from other members.
+    for witness in &witnesses {
+        _query_mailbox_for(id, signer, multisig_id, witness).await?;
     }
 
     // Round 2: collect witness receipts.
-    for witness in witnesses {
-        _query_mailbox_for(id, signer, group_id, witness).await?;
+    for witness in &witnesses {
+        _query_mailbox_for(id, signer, multisig_id, witness).await?;
     }
 
     Ok(())
 }
 
-/// Query this participant's mailbox for pending multisig requests.
+/// Poll for pending delegation or multisig requests in this
+/// identifier's mailbox.
 ///
-/// Returns a list of [`MultisigRequest`] items found, filtering out
-/// non-multisig actions. This is a convenience wrapper around
-/// [`query_mailbox`] + [`MultisigRequest::try_from`].
+/// Returns all discovered requests as [`PendingRequest`] items. Use
+/// [`PendingRequest::into_delegation`] or
+/// [`PendingRequest::into_multisig`] to extract the specific type and
+/// pass it to [`approve_delegation`] or [`accept_multisig`].
 ///
 /// # Errors
+/// - [`Error::NoWitnesses`] if the identifier has no witnesses configured.
 /// - [`Error::Mechanics`] on network failures.
 /// - [`Error::Signing`] if signing fails.
-pub async fn query_multisig_requests<S: SigningBackend + Clone + 'static>(
+pub async fn poll_pending_requests<S: SigningBackend + Clone + 'static>(
     id: &mut Identifier,
     signer: &S,
-    witnesses: &[BasicPrefix],
-) -> Result<Vec<MultisigRequest>> {
+) -> Result<Vec<PendingRequest>> {
     let own_id = id.id().clone();
+    let witnesses: Vec<BasicPrefix> = id.witnesses().collect();
+    if witnesses.is_empty() {
+        return Err(Error::NoWitnesses(own_id));
+    }
     let mut requests = vec![];
-    for witness in witnesses {
+    for witness in &witnesses {
         let actions = _query_mailbox_for(id, signer, &own_id, witness).await?;
         for action in actions {
-            if let Ok(req) = MultisigRequest::try_from(action) {
+            if let Ok(req) = PendingRequest::try_from(action) {
                 requests.push(req);
             }
         }

--- a/keriox_sdk/src/operations.rs
+++ b/keriox_sdk/src/operations.rs
@@ -25,7 +25,10 @@ use crate::{
     controller::Controller,
     error::{Error, Result},
     identifier::{Identifier, ActionRequired},
-    types::{DelegationConfig, DelegationRequest, IdentifierConfig, RotationConfig},
+    types::{
+        DelegationConfig, DelegationRequest, GroupConfig, IdentifierConfig, MultisigRequest,
+        RotationConfig,
+    },
 };
 
 // ── Internal helpers ─────────────────────────────────────────────────────────
@@ -581,4 +584,165 @@ pub async fn finalize_delegation<S: SigningBackend + Clone + 'static>(
     }
 
     Ok(())
+}
+
+// ── Multisig operations ──────────────────────────────────────────────────────
+
+/// Create a multisig group identifier (initiator side).
+///
+/// Generates the group inception event, signs it with the caller's key,
+/// and sends exchange messages to all other participants via witnesses.
+///
+/// The group identifier is **not** yet accepted — other participants must
+/// co-sign via [`join_group`], and all participants must call
+/// [`collect_group_signatures`] to finalise.
+///
+/// Returns the group `IdentifierPrefix`.
+///
+/// # Preconditions
+/// - `id` must be a fully established individual identifier with witnesses.
+/// - The caller must have resolved all participants' KELs (via watcher/OOBI).
+///
+/// # Errors
+/// - [`Error::Controller`] if group inception generation fails.
+/// - [`Error::Mechanics`] on network failures.
+/// - [`Error::Signing`] if signing fails.
+pub async fn create_group_identifier<S: SigningBackend + Clone + 'static>(
+    id: &mut Identifier,
+    signer: &S,
+    config: GroupConfig,
+) -> Result<IdentifierPrefix> {
+    let witness_ids: Vec<BasicPrefix> = config
+        .witnesses
+        .iter()
+        .filter_map(|w| {
+            if let IdentifierPrefix::Basic(b) = &w.eid {
+                Some(b.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let (icp, exn_messages) = id.incept_group(
+        config.participants,
+        config.signature_threshold,
+        config.next_keys_threshold,
+        Some(witness_ids),
+        Some(config.witness_threshold),
+        config.delegator,
+    )?;
+
+    let sig_icp = ed25519_sig(signer, icp.as_bytes())?;
+
+    // Sign each exchange message (one per participant, plus optional delegation).
+    let mut exchange_pairs = Vec::with_capacity(exn_messages.len());
+    for exn in &exn_messages {
+        let sig_exn = ed25519_sig(signer, exn.as_bytes())?;
+        let exn_index_sig = id.sign_with_index(sig_exn, 0)?;
+        exchange_pairs.push((exn.as_bytes().to_vec(), exn_index_sig));
+    }
+
+    let group_prefix = id
+        .finalize_group_incept(icp.as_bytes(), sig_icp, exchange_pairs)
+        .await?;
+
+    Ok(group_prefix)
+}
+
+/// Co-sign a multisig group event discovered in the mailbox (joiner side).
+///
+/// The `request` is obtained by calling [`query_multisig_requests`] or by
+/// converting an [`ActionRequired::MultisigRequest`] into a
+/// [`MultisigRequest`].
+///
+/// # Errors
+/// - [`Error::EncodingError`] if event encoding fails.
+/// - [`Error::Mechanics`] on network failures.
+/// - [`Error::Signing`] if signing fails.
+pub async fn join_group<S: SigningBackend + Clone + 'static>(
+    id: &mut Identifier,
+    signer: &S,
+    request: MultisigRequest,
+) -> Result<()> {
+    let encoded_event = request
+        .event
+        .encode()
+        .map_err(|e| Error::EncodingError(e.to_string()))?;
+    let encoded_exn = request
+        .exchange
+        .encode()
+        .map_err(|e| Error::EncodingError(e.to_string()))?;
+
+    let sig_event = ed25519_sig(signer, &encoded_event)?;
+    let sig_exn = ed25519_sig(signer, &encoded_exn)?;
+    let exn_index_sig = id.sign_with_index(sig_exn, 0)?;
+
+    id.finalize_group_event(
+        &encoded_event,
+        sig_event,
+        vec![(encoded_exn, exn_index_sig)],
+    )
+    .await?;
+
+    Ok(())
+}
+
+/// Collect co-signatures and witness receipts for a group event.
+///
+/// Queries the group identifier's mailbox in two rounds (matching the
+/// protocol requirement for signature collection followed by receipt
+/// collection). Must be called by **all** participants after the group
+/// event has been co-signed by enough participants.
+///
+/// After this call, verify acceptance with
+/// `id.find_state(group_id)`.
+///
+/// # Errors
+/// - [`Error::Mechanics`] on network or mailbox failures.
+/// - [`Error::Signing`] if signing fails.
+pub async fn collect_group_signatures<S: SigningBackend + Clone + 'static>(
+    id: &mut Identifier,
+    signer: &S,
+    group_id: &IdentifierPrefix,
+    witnesses: &[BasicPrefix],
+) -> Result<()> {
+    // Round 1: collect co-signatures from other participants.
+    for witness in witnesses {
+        _query_mailbox_for(id, signer, group_id, witness).await?;
+    }
+
+    // Round 2: collect witness receipts.
+    for witness in witnesses {
+        _query_mailbox_for(id, signer, group_id, witness).await?;
+    }
+
+    Ok(())
+}
+
+/// Query this participant's mailbox for pending multisig requests.
+///
+/// Returns a list of [`MultisigRequest`] items found, filtering out
+/// non-multisig actions. This is a convenience wrapper around
+/// [`query_mailbox`] + [`MultisigRequest::try_from`].
+///
+/// # Errors
+/// - [`Error::Mechanics`] on network failures.
+/// - [`Error::Signing`] if signing fails.
+pub async fn query_multisig_requests<S: SigningBackend + Clone + 'static>(
+    id: &mut Identifier,
+    signer: &S,
+    witnesses: &[BasicPrefix],
+) -> Result<Vec<MultisigRequest>> {
+    let own_id = id.id().clone();
+    let mut requests = vec![];
+    for witness in witnesses {
+        let actions = _query_mailbox_for(id, signer, &own_id, witness).await?;
+        for action in actions {
+            if let Ok(req) = MultisigRequest::try_from(action) {
+                requests.push(req);
+            }
+        }
+    }
+    Ok(requests)
 }

--- a/keriox_sdk/src/operations.rs
+++ b/keriox_sdk/src/operations.rs
@@ -3,20 +3,23 @@
 //! These functions combine multiple low-level steps (event generation,
 //! signing, witness notification, mailbox queries) so callers don't need to
 //! orchestrate individual calls. All signing is done internally with the
-//! provided [`Signer`] — callers never touch raw CESR prefix types.
+//! provided signer — callers never touch raw CESR prefix types.
+//!
+//! When the `keyprovider` feature is enabled, all functions accept
+//! [`KeriSigner`](crate::keyprovider_adapter::KeriSigner) which can wrap
+//! either a legacy `Signer` or any `KeyProvider` implementation.
+//! Without the feature, they accept `Arc<Signer>`.
 //!
 //! For persistence of identifiers across sessions see [`crate::store`].
 //! For signing arbitrary payloads see [`crate::signing`].
 
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use keri_controller::{BasicPrefix, IdentifierPrefix, LocationScheme, Oobi, SelfSigningPrefix};
 use keri_core::{
     actor::prelude::SelfAddressingIdentifier,
     prefix::IndexedSignature,
     query::mailbox::SignedMailboxQuery,
-    signer::Signer,
 };
 
 use keri_core::event_message::signed_event_message::Notice;
@@ -31,12 +34,66 @@ use crate::{
     },
 };
 
+// ── Signer abstraction ────────────────────────────────────────────────────────
+
+/// Trait abstracting what operations need from a signer.
+///
+/// Implemented for `Arc<Signer>` (always) and
+/// `KeriSigner` (when the `keyprovider` feature is enabled).
+/// Trait abstracting what operations need from any signer.
+///
+/// Implemented for `Arc<Signer>` (always) and
+/// `KeriSigner` (when the `keyprovider` feature is enabled).
+pub trait SigningBackend {
+    /// Sign a message, returning raw signature bytes.
+    fn sign_data(&self, data: &[u8]) -> Result<Vec<u8>>;
+    /// Return the public key.
+    fn public_key(&self) -> keri_core::keys::PublicKey;
+}
+
+impl SigningBackend for std::sync::Arc<keri_core::signer::Signer> {
+    fn sign_data(&self, data: &[u8]) -> Result<Vec<u8>> {
+        self.sign(data)
+            .map_err(|e| Error::Signing(e.to_string()))
+    }
+
+    fn public_key(&self) -> keri_core::keys::PublicKey {
+        keri_core::signer::Signer::public_key(self)
+    }
+}
+
+#[cfg(feature = "keyprovider")]
+impl SigningBackend for crate::keyprovider_adapter::KeriSigner {
+    fn sign_data(&self, data: &[u8]) -> Result<Vec<u8>> {
+        self.sign(data)
+    }
+
+    fn public_key(&self) -> keri_core::keys::PublicKey {
+        self.public_key()
+    }
+}
+
+#[cfg(feature = "keyprovider")]
+impl SigningBackend for std::sync::Arc<dyn keri_keyprovider::KeyProvider> {
+    fn sign_data(&self, data: &[u8]) -> Result<Vec<u8>> {
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async {
+                self.sign(data).await
+            })
+        })
+        .map_err(|e| Error::Signing(e.to_string()))
+    }
+
+    fn public_key(&self) -> keri_core::keys::PublicKey {
+        let pk_data = keri_keyprovider::KeyProvider::public_key(self);
+        keri_core::keys::PublicKey::new(pk_data.bytes.clone())
+    }
+}
+
 // ── Internal helpers ─────────────────────────────────────────────────────────
 
-pub(crate) fn ed25519_sig(signer: &Signer, data: &[u8]) -> Result<SelfSigningPrefix> {
-    let bytes = signer
-        .sign(data)
-        .map_err(|e| Error::Signing(e.to_string()))?;
+pub(crate) fn ed25519_sig(signer: &dyn SigningBackend, data: &[u8]) -> Result<SelfSigningPrefix> {
+    let bytes = signer.sign_data(data)?;
     Ok(SelfSigningPrefix::new(
         cesrox::primitives::codes::self_signing::SelfSigning::Ed25519Sha512,
         bytes,
@@ -58,9 +115,9 @@ pub(crate) fn ed25519_sig(signer: &Signer, data: &[u8]) -> Result<SelfSigningPre
 /// - [`Error::Controller`] if event generation or finalisation fails.
 /// - [`Error::Mechanics`] if witness notification or mailbox queries fail.
 /// - [`Error::Signing`] if the signer fails to produce a signature.
-pub async fn create_identifier(
-    db_path: PathBuf,
-    signer: Arc<Signer>,
+pub async fn create_identifier<S: SigningBackend + Clone + 'static>(
+    db_path: std::path::PathBuf,
+    signer: S,
     next_pk: BasicPrefix,
     config: IdentifierConfig,
 ) -> Result<Identifier> {
@@ -79,17 +136,17 @@ pub async fn create_identifier(
 
     for wit in &config.witnesses {
         if let IdentifierPrefix::Basic(wit_id) = &wit.eid {
-            _query_mailbox(&mut id, signer.clone(), wit_id).await?;
+            _query_mailbox(&mut id, &signer, wit_id).await?;
         }
         id.send_oobi_to_watcher(id.id(), &Oobi::Location(wit.clone()))
             .await?;
         if let IdentifierPrefix::Basic(wit_id) = &wit.eid {
-            _query_mailbox(&mut id, signer.clone(), wit_id).await?;
+            _query_mailbox(&mut id, &signer, wit_id).await?;
         }
     }
 
     for watch in &config.watchers {
-        add_watcher(&mut id, signer.clone(), watch).await?;
+        add_watcher(&mut id, &signer, watch).await?;
     }
 
     Ok(id)
@@ -100,9 +157,9 @@ pub async fn create_identifier(
 /// # Deprecated
 /// Use [`create_identifier`] with an [`IdentifierConfig`] instead.
 #[deprecated(since = "0.2.0", note = "use create_identifier with IdentifierConfig")]
-pub async fn setup_identifier(
+pub async fn setup_identifier<S: SigningBackend + Clone + 'static>(
     controller: &Controller,
-    signer: Arc<Signer>,
+    signer: S,
     next_pk: BasicPrefix,
     witnesses: Vec<LocationScheme>,
     witness_threshold: u64,
@@ -122,17 +179,17 @@ pub async fn setup_identifier(
 
     for wit in &witnesses {
         if let IdentifierPrefix::Basic(wit_id) = &wit.eid {
-            _query_mailbox(&mut id, signer.clone(), wit_id).await?;
+            _query_mailbox(&mut id, &signer, wit_id).await?;
         }
         id.send_oobi_to_watcher(id.id(), &Oobi::Location(wit.clone()))
             .await?;
         if let IdentifierPrefix::Basic(wit_id) = &wit.eid {
-            _query_mailbox(&mut id, signer.clone(), wit_id).await?;
+            _query_mailbox(&mut id, &signer, wit_id).await?;
         }
     }
 
     for watch in &watchers {
-        add_watcher(&mut id, signer.clone(), watch).await?;
+        add_watcher(&mut id, &signer, watch).await?;
     }
 
     Ok(id)
@@ -146,14 +203,14 @@ pub async fn setup_identifier(
 /// # Errors
 /// - [`Error::Mechanics`] if OOBI resolution or the network call fails.
 /// - [`Error::Signing`] if signing the reply fails.
-pub async fn add_watcher(
+pub async fn add_watcher<S: SigningBackend>(
     id: &mut Identifier,
-    km: Arc<Signer>,
+    km: &S,
     watcher_oobi: &LocationScheme,
 ) -> Result<()> {
     id.resolve_oobi(&Oobi::Location(watcher_oobi.clone())).await?;
     let rpy = id.add_watcher(watcher_oobi.eid.clone())?;
-    let sig = ed25519_sig(&km, rpy.as_bytes())?;
+    let sig = ed25519_sig(km, rpy.as_bytes())?;
     id.finalize_add_watcher(rpy.as_bytes(), sig).await?;
     Ok(())
 }
@@ -167,9 +224,9 @@ pub async fn add_watcher(
 /// - [`Error::Controller`] if rotation event generation fails.
 /// - [`Error::Mechanics`] if witness notification or mailbox queries fail.
 /// - [`Error::Signing`] if signing fails.
-pub async fn rotate(
+pub async fn rotate<S: SigningBackend + Clone + 'static>(
     id: &mut Identifier,
-    current_signer: Arc<Signer>,
+    current_signer: S,
     config: RotationConfig,
 ) -> Result<()> {
     let current_keys = vec![BasicPrefix::Ed25519NT(current_signer.public_key())];
@@ -192,7 +249,7 @@ pub async fn rotate(
 
     let witnesses = id.find_state(id.id())?.witness_config.witnesses;
     for witness in witnesses {
-        _query_mailbox(id, current_signer.clone(), &witness).await?;
+        _query_mailbox(id, &current_signer, &witness).await?;
     }
 
     Ok(())
@@ -203,9 +260,9 @@ pub async fn rotate(
 /// # Deprecated
 /// Use [`rotate`] with a [`RotationConfig`] instead.
 #[deprecated(since = "0.2.0", note = "use rotate with RotationConfig")]
-pub async fn rotate_identifier(
+pub async fn rotate_identifier<S: SigningBackend + Clone + 'static>(
     id: &mut Identifier,
-    current_signer: Arc<Signer>,
+    current_signer: S,
     new_next_keys: Vec<BasicPrefix>,
     new_next_threshold: u64,
     witness_to_add: Vec<LocationScheme>,
@@ -231,7 +288,7 @@ pub async fn rotate_identifier(
 
     let witnesses = id.find_state(id.id())?.witness_config.witnesses;
     for witness in witnesses {
-        _query_mailbox(id, current_signer.clone(), &witness).await?;
+        _query_mailbox(id, &current_signer, &witness).await?;
     }
 
     Ok(())
@@ -247,9 +304,9 @@ pub async fn rotate_identifier(
 /// - [`Error::Controller`] if registry inception or encoding fails.
 /// - [`Error::Mechanics`] on network failures.
 /// - [`Error::Signing`] if signing fails.
-pub async fn incept_registry(
+pub async fn incept_registry<S: SigningBackend + Clone + 'static>(
     id: &mut Identifier,
-    signer: Arc<Signer>,
+    signer: S,
 ) -> Result<IdentifierPrefix> {
     let (reg_id, ixn) = id.incept_registry()?;
     let encoded_ixn = ixn
@@ -261,7 +318,7 @@ pub async fn incept_registry(
 
     let witnesses = id.find_state(id.id())?.witness_config.witnesses;
     for witness in &witnesses {
-        _query_mailbox(id, signer.clone(), witness).await?;
+        _query_mailbox(id, &signer, witness).await?;
     }
 
     id.notify_backers().await?;
@@ -278,9 +335,9 @@ pub async fn incept_registry(
 /// - [`Error::Controller`] if event generation or encoding fails.
 /// - [`Error::Mechanics`] on network failures.
 /// - [`Error::Signing`] if signing fails.
-pub async fn issue(
+pub async fn issue<S: SigningBackend + Clone + 'static>(
     id: &mut Identifier,
-    signer: Arc<Signer>,
+    signer: S,
     credential_said: SelfAddressingIdentifier,
 ) -> Result<()> {
     let (_vc_id, ixn) = id.issue(credential_said)?;
@@ -296,7 +353,7 @@ pub async fn issue(
         .witness_config
         .witnesses;
     for witness in &witnesses {
-        _query_mailbox(id, signer.clone(), witness).await?;
+        _query_mailbox(id, &signer, witness).await?;
     }
 
     id.notify_backers().await?;
@@ -309,10 +366,10 @@ pub async fn issue(
 /// # Deprecated
 /// Use [`issue`] instead.
 #[deprecated(since = "0.2.0", note = "use issue(id, signer, cred_said)")]
-pub async fn issue_credential(
+pub async fn issue_credential<S: SigningBackend + Clone + 'static>(
     identifier: &mut Identifier,
     cred_said: SelfAddressingIdentifier,
-    km: Arc<Signer>,
+    km: S,
 ) -> Result<()> {
     issue(identifier, km, cred_said).await
 }
@@ -326,9 +383,9 @@ pub async fn issue_credential(
 /// - [`Error::Controller`] if event generation fails.
 /// - [`Error::Mechanics`] on network failures.
 /// - [`Error::Signing`] if signing fails.
-pub async fn revoke(
+pub async fn revoke<S: SigningBackend + Clone + 'static>(
     id: &mut Identifier,
-    signer: Arc<Signer>,
+    signer: S,
     credential_said: &SelfAddressingIdentifier,
 ) -> Result<()> {
     let ixn = id.revoke(credential_said)?;
@@ -341,7 +398,7 @@ pub async fn revoke(
         .witness_config
         .witnesses;
     for witness in &witnesses {
-        _query_mailbox(id, signer.clone(), witness).await?;
+        _query_mailbox(id, &signer, witness).await?;
     }
 
     id.notify_backers().await?;
@@ -354,10 +411,10 @@ pub async fn revoke(
 /// # Deprecated
 /// Use [`revoke`] instead.
 #[deprecated(since = "0.2.0", note = "use revoke(id, signer, cred_said)")]
-pub async fn revoke_credential(
+pub async fn revoke_credential<S: SigningBackend + Clone + 'static>(
     identifier: &mut Identifier,
     cred_said: &SelfAddressingIdentifier,
-    km: Arc<Signer>,
+    km: S,
 ) -> Result<()> {
     revoke(identifier, km, cred_said).await
 }
@@ -372,27 +429,24 @@ pub async fn revoke_credential(
 /// - [`Error::Mechanics`] on network or processing failures.
 /// - [`Error::Signing`] if signing fails.
 /// - [`Error::EncodingError`] if query encoding fails.
-pub async fn query_mailbox(
+pub async fn query_mailbox<S: SigningBackend>(
     id: &mut Identifier,
-    km: Arc<Signer>,
+    km: S,
     witness_id: &BasicPrefix,
 ) -> Result<Vec<SignedMailboxQuery>> {
-    _query_mailbox(id, km, witness_id).await
+    _query_mailbox(id, &km, witness_id).await
 }
 
 // Private implementation to avoid name collision with Identifier::query_mailbox.
-async fn _query_mailbox(
+async fn _query_mailbox<S: SigningBackend>(
     id: &mut Identifier,
-    km: Arc<Signer>,
+    km: &S,
     witness_id: &BasicPrefix,
 ) -> Result<Vec<SignedMailboxQuery>> {
     let mut out = vec![];
     for qry in id.query_mailbox(id.id(), &[witness_id.clone()])? {
         let encoded = qry.encode().map_err(|e| Error::EncodingError(e.to_string()))?;
-        let sig = SelfSigningPrefix::Ed25519Sha512(
-            km.sign(&encoded)
-                .map_err(|e| Error::Signing(e.to_string()))?,
-        );
+        let sig = SelfSigningPrefix::Ed25519Sha512(km.sign_data(&encoded)?);
         let signatures = vec![IndexedSignature::new_both_same(sig.clone(), 0)];
         let signed_qry =
             SignedMailboxQuery::new_trans(qry.clone(), id.id().clone(), signatures);

--- a/keriox_sdk/src/operations.rs
+++ b/keriox_sdk/src/operations.rs
@@ -19,11 +19,13 @@ use keri_core::{
     signer::Signer,
 };
 
+use keri_core::event_message::signed_event_message::Notice;
+
 use crate::{
     controller::Controller,
     error::{Error, Result},
-    identifier::Identifier,
-    types::{IdentifierConfig, RotationConfig},
+    identifier::{Identifier, ActionRequired},
+    types::{DelegationConfig, DelegationRequest, IdentifierConfig, RotationConfig},
 };
 
 // ── Internal helpers ─────────────────────────────────────────────────────────
@@ -395,4 +397,188 @@ async fn _query_mailbox(
         out.push(signed_qry);
     }
     Ok(out)
+}
+
+/// Like `_query_mailbox` but queries for an arbitrary identifier (not just
+/// the identifier's own prefix). Returns any `ActionRequired` items.
+async fn _query_mailbox_for<S: SigningBackend>(
+    id: &mut Identifier,
+    km: &S,
+    about: &IdentifierPrefix,
+    witness_id: &BasicPrefix,
+) -> Result<Vec<ActionRequired>> {
+    let mut actions = vec![];
+    for qry in id.query_mailbox(about, &[witness_id.clone()])? {
+        let encoded = qry
+            .encode()
+            .map_err(|e| Error::EncodingError(e.to_string()))?;
+        let sig = SelfSigningPrefix::Ed25519Sha512(km.sign_data(&encoded)?);
+        let result = id.finalize_query_mailbox(vec![(qry, sig)]).await?;
+        actions.extend(result);
+    }
+    Ok(actions)
+}
+
+// ── Delegation operations ────────────────────────────────────────────────────
+
+/// Create a delegated identifier (delegatee side, step 1 of 2).
+///
+/// Internally creates a temporary helper identifier, generates a DIP
+/// (delegated inception) event, signs it, and sends the delegation request
+/// to the delegator via witnesses.
+///
+/// The delegated identifier is **not** yet accepted — the delegator must
+/// approve it first. After approval, call [`finalize_delegation`] with
+/// the returned `Identifier` and prefix.
+///
+/// Returns `(temporary_identifier, delegated_prefix)`.
+///
+/// # Errors
+/// - [`Error::Controller`] on event generation failures.
+/// - [`Error::Mechanics`] on network failures.
+/// - [`Error::Signing`] if signing fails.
+pub async fn create_delegated_identifier<S: SigningBackend + Clone + 'static>(
+    db_path: PathBuf,
+    signer: S,
+    next_pk: BasicPrefix,
+    config: DelegationConfig,
+) -> Result<(Identifier, IdentifierPrefix)> {
+    // Step 1: Create a temporary identifier (needed by incept_group).
+    let temp_config = IdentifierConfig {
+        witnesses: config.witnesses.clone(),
+        witness_threshold: config.witness_threshold,
+        watchers: vec![], // watchers configured after delegation is accepted
+    };
+    let mut temp_id = create_identifier(db_path, signer.clone(), next_pk, temp_config).await?;
+
+    // Step 2: Extract witness BasicPrefixes for the delegated identifier.
+    let witness_ids: Vec<BasicPrefix> = config
+        .witnesses
+        .iter()
+        .filter_map(|w| {
+            if let IdentifierPrefix::Basic(b) = &w.eid {
+                Some(b.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // Step 3: Generate delegated inception (DIP) + exchange messages.
+    let (dip, exn_messages) = temp_id.incept_group(
+        vec![],
+        1,
+        Some(1),
+        Some(witness_ids),
+        Some(config.witness_threshold),
+        Some(config.delegator),
+    )?;
+
+    // Step 4: Sign and finalise.
+    let sig_icp = ed25519_sig(&signer, dip.as_bytes())?;
+
+    // The last exchange message is the delegation request to the delegator.
+    let delegation_exn = exn_messages
+        .last()
+        .ok_or_else(|| Error::DelegationError("no exchange message generated".into()))?;
+    let sig_exn = ed25519_sig(&signer, delegation_exn.as_bytes())?;
+    let exn_index_sig = temp_id.sign_with_index(sig_exn, 0)?;
+
+    let delegated_prefix = temp_id
+        .finalize_group_incept(
+            dip.as_bytes(),
+            sig_icp,
+            vec![(delegation_exn.as_bytes().to_vec(), exn_index_sig)],
+        )
+        .await?;
+
+    Ok((temp_id, delegated_prefix))
+}
+
+/// Approve a pending delegation request (delegator side).
+///
+/// Signs the delegating IXN event, notifies witnesses, queries the mailbox
+/// for receipts, and sends the exchange message (approval notification) to
+/// the delegatee via witnesses.
+///
+/// The `request` is typically obtained by calling
+/// [`query_mailbox`] and converting the resulting
+/// [`ActionRequired::DelegationRequest`] into a [`DelegationRequest`].
+///
+/// # Errors
+/// - [`Error::Mechanics`] on network failures.
+/// - [`Error::Signing`] if signing fails.
+/// - [`Error::EncodingError`] if event encoding fails.
+pub async fn approve_delegation<S: SigningBackend + Clone + 'static>(
+    id: &mut Identifier,
+    signer: &S,
+    request: DelegationRequest,
+) -> Result<()> {
+    let encoded_ixn = request
+        .delegating_event
+        .encode()
+        .map_err(|e| Error::EncodingError(e.to_string()))?;
+    let encoded_exn = request
+        .exchange
+        .encode()
+        .map_err(|e| Error::EncodingError(e.to_string()))?;
+
+    let sig_ixn = ed25519_sig(signer, &encoded_ixn)?;
+
+    // Finalise the delegating IXN.
+    id.finalize_group_event(&encoded_ixn, sig_ixn.clone(), vec![])
+        .await?;
+    id.notify_witnesses().await?;
+
+    // Query mailbox for IXN receipts.
+    let witnesses = id.find_state(id.id())?.witness_config.witnesses;
+    for witness in &witnesses {
+        _query_mailbox(id, signer, witness).await?;
+    }
+
+    // Send exchange (approval) to delegatee via witnesses.
+    let sig_exn = ed25519_sig(signer, &encoded_exn)?;
+    let data_signature = IndexedSignature::new_both_same(sig_ixn, 0);
+    let exn_index_sig = id.sign_with_index(sig_exn, 0)?;
+    id.finalize_exchange(&encoded_exn, exn_index_sig, data_signature)
+        .await?;
+
+    Ok(())
+}
+
+/// Complete the delegation process after the delegator approves (delegatee
+/// side, step 2 of 2).
+///
+/// Saves the delegator's KEL into the local database, then queries the
+/// delegated identifier's mailbox until the DIP event is accepted.
+///
+/// `delegator_kel` is the delegator's KEL (inception + receipts) obtained
+/// out-of-band or via OOBI resolution.
+///
+/// # Errors
+/// - [`Error::Mechanics`] on network or mailbox failures.
+/// - [`Error::Signing`] if signing fails.
+pub async fn finalize_delegation<S: SigningBackend + Clone + 'static>(
+    temp_id: &mut Identifier,
+    signer: &S,
+    delegated_prefix: &IdentifierPrefix,
+    delegator_kel: Vec<Notice>,
+    witnesses: &[BasicPrefix],
+) -> Result<()> {
+    // Save the delegator's KEL events into local DB.
+    for notice in &delegator_kel {
+        temp_id.save_notice(notice)?;
+    }
+
+    // Query mailbox for the delegated identifier to get the delegating event.
+    for witness in witnesses {
+        _query_mailbox_for(temp_id, signer, delegated_prefix, witness).await?;
+    }
+
+    // Query again to get witness receipts (the DIP may now be accepted).
+    for witness in witnesses {
+        _query_mailbox_for(temp_id, signer, delegated_prefix, witness).await?;
+    }
+
+    Ok(())
 }

--- a/keriox_sdk/src/signing.rs
+++ b/keriox_sdk/src/signing.rs
@@ -10,8 +10,8 @@
 //! use keri_sdk::{signing, Identifier, Signer};
 //! use std::sync::Arc;
 //!
-//! # fn example(id: &Identifier, signer: &Signer) -> keri_sdk::Result<()> {
-//! let envelope = signing::sign(id, signer, b"hello world")?;
+//! # fn example(id: &Identifier, signer: Arc<Signer>) -> keri_sdk::Result<()> {
+//! let envelope = signing::sign(id, &signer, b"hello world")?;
 //! println!("CESR: {}", envelope.cesr);
 //!
 //! let verified = signing::verify(id, envelope.cesr.as_bytes())?;
@@ -21,11 +21,11 @@
 //! ```
 
 use keri_core::event_message::signature::{get_signatures, Signature};
-use keri_core::signer::Signer;
 
 use crate::{
     error::{Error, Result},
     identifier::Identifier,
+    operations::SigningBackend,
     types::{SignedEnvelope, VerifiedPayload},
 };
 
@@ -36,9 +36,8 @@ use crate::{
 
 fn wrap_payload(data: &[u8]) -> Result<String> {
     let (p, e): (&str, &str) = if let Ok(s) = std::str::from_utf8(data) {
-        (s, "text")  // valid UTF-8: store as-is
+        (s, "text")
     } else {
-        // binary: store as base64url
         return Ok(serde_json::to_string(&serde_json::json!({
             "p": base64::encode_config(data, base64::URL_SAFE_NO_PAD),
             "e": "b64"
@@ -73,12 +72,14 @@ fn unwrap_payload(json_bytes: &[u8]) -> Result<Vec<u8>> {
 /// - [`Error::Signing`] if the signer fails.
 /// - [`Error::EncodingError`] if JSON serialisation of the wrapper fails.
 /// - [`Error::Controller`] if the CESR envelope cannot be built.
-pub fn sign(identifier: &Identifier, signer: &Signer, data: &[u8]) -> Result<SignedEnvelope> {
+pub fn sign<S: SigningBackend>(
+    identifier: &Identifier,
+    signer: &S,
+    data: &[u8],
+) -> Result<SignedEnvelope> {
     let json_payload = wrap_payload(data)?;
 
-    let raw_sig = signer
-        .sign(json_payload.as_bytes())
-        .map_err(|e| Error::Signing(e.to_string()))?;
+    let raw_sig = signer.sign_data(json_payload.as_bytes())?;
 
     let sig = keri_controller::SelfSigningPrefix::new(
         cesrox::primitives::codes::self_signing::SelfSigning::Ed25519Sha512,
@@ -101,7 +102,11 @@ pub fn sign(identifier: &Identifier, signer: &Signer, data: &[u8]) -> Result<Sig
 ///
 /// # Errors
 /// Same as [`sign`].
-pub fn sign_json(identifier: &Identifier, signer: &Signer, json: &str) -> Result<SignedEnvelope> {
+pub fn sign_json<S: SigningBackend>(
+    identifier: &Identifier,
+    signer: &S,
+    json: &str,
+) -> Result<SignedEnvelope> {
     sign(identifier, signer, json.as_bytes())
 }
 

--- a/keriox_sdk/src/store.rs
+++ b/keriox_sdk/src/store.rs
@@ -42,8 +42,8 @@ use crate::{
     controller::Controller,
     error::{Error, Result},
     identifier::Identifier,
-    operations::{create_identifier, create_delegated_identifier},
-    types::{DelegationConfig, IdentifierConfig},
+    operations::{create_identifier, create_delegated_identifier, create_group_identifier},
+    types::{DelegationConfig, GroupConfig, IdentifierConfig},
 };
 
 /// Manages a directory of named KERI identifiers.
@@ -329,6 +329,119 @@ impl KeriStore {
         let s = self.read_file(alias, "delegator_id")?;
         IdentifierPrefix::from_str(s.trim())
             .map_err(|_| Error::PersistenceError("invalid delegator_id".into()))
+    }
+
+    /// Create a multisig group identifier and persist metadata (initiator side).
+    ///
+    /// The caller's individual identifier must already exist under
+    /// `member_alias`. This method creates a new alias directory for the
+    /// group that stores the group prefix, participant list, and a back-
+    /// reference to the member alias.
+    ///
+    /// Other participants must still co-sign via
+    /// [`crate::operations::join_group`], and all participants must call
+    /// [`crate::operations::collect_group_signatures`] to finalise.
+    ///
+    /// Returns the group `IdentifierPrefix`.
+    ///
+    /// # Errors
+    /// - [`Error::PersistenceError`] on I/O failures.
+    /// - Propagates errors from [`create_group_identifier`].
+    pub async fn create_group(
+        &self,
+        group_alias: &str,
+        member_alias: &str,
+        config: GroupConfig,
+    ) -> Result<IdentifierPrefix> {
+        let mut id = self.load(member_alias)?;
+        let signer = self.load_signer(member_alias)?;
+
+        let participants = config.participants.clone();
+        let group_prefix = create_group_identifier(&mut id, &signer, config).await?;
+
+        // Persist group metadata under the group alias.
+        let alias_dir = self.alias_dir(group_alias);
+        std::fs::create_dir_all(&alias_dir)
+            .map_err(|e| Error::PersistenceError(format!("cannot create alias dir: {e}")))?;
+
+        use keri_core::prefix::CesrPrimitive;
+        self.write_file(group_alias, "group_id", &group_prefix.to_str())?;
+        self.write_file(group_alias, "member_alias", member_alias)?;
+
+        let participant_strs: Vec<String> =
+            participants.iter().map(|p| p.to_str()).collect();
+        let json = serde_json::to_string(&participant_strs)
+            .map_err(|e| Error::PersistenceError(format!("cannot serialise participants: {e}")))?;
+        self.write_file(group_alias, "participants", &json)?;
+
+        Ok(group_prefix)
+    }
+
+    /// Persist group metadata after joining a group (joiner side).
+    ///
+    /// Call this after [`crate::operations::join_group`] to record the group
+    /// prefix, participant list, and member alias for later retrieval.
+    ///
+    /// # Errors
+    /// - [`Error::PersistenceError`] on I/O failures.
+    pub fn save_group(
+        &self,
+        group_alias: &str,
+        group_id: &IdentifierPrefix,
+        participants: &[IdentifierPrefix],
+        member_alias: &str,
+    ) -> Result<()> {
+        let alias_dir = self.alias_dir(group_alias);
+        std::fs::create_dir_all(&alias_dir)
+            .map_err(|e| Error::PersistenceError(format!("cannot create alias dir: {e}")))?;
+
+        use keri_core::prefix::CesrPrimitive;
+        self.write_file(group_alias, "group_id", &group_id.to_str())?;
+        self.write_file(group_alias, "member_alias", member_alias)?;
+
+        let participant_strs: Vec<String> =
+            participants.iter().map(|p| p.to_str()).collect();
+        let json = serde_json::to_string(&participant_strs)
+            .map_err(|e| Error::PersistenceError(format!("cannot serialise participants: {e}")))?;
+        self.write_file(group_alias, "participants", &json)?;
+
+        Ok(())
+    }
+
+    /// Load the group identifier prefix for an alias.
+    ///
+    /// # Errors
+    /// - [`Error::PersistenceError`] if the `group_id` file is missing or invalid.
+    pub fn load_group_prefix(&self, alias: &str) -> Result<IdentifierPrefix> {
+        let s = self.read_file(alias, "group_id")?;
+        IdentifierPrefix::from_str(s.trim())
+            .map_err(|_| Error::PersistenceError("invalid group_id".into()))
+    }
+
+    /// Load the participant list for a group alias.
+    ///
+    /// # Errors
+    /// - [`Error::PersistenceError`] if the `participants` file is missing or invalid.
+    pub fn load_group_participants(&self, alias: &str) -> Result<Vec<IdentifierPrefix>> {
+        let json = self.read_file(alias, "participants")?;
+        let strs: Vec<String> = serde_json::from_str(&json)
+            .map_err(|e| Error::PersistenceError(format!("invalid participants JSON: {e}")))?;
+        strs.iter()
+            .map(|s| {
+                IdentifierPrefix::from_str(s.trim())
+                    .map_err(|_| Error::PersistenceError(format!("invalid participant: {s}")))
+            })
+            .collect()
+    }
+
+    /// Load the member alias for a group alias (back-reference to the
+    /// individual identifier used by this participant).
+    ///
+    /// # Errors
+    /// - [`Error::PersistenceError`] if the `member_alias` file is missing.
+    pub fn load_group_member_alias(&self, alias: &str) -> Result<String> {
+        self.read_file(alias, "member_alias")
+            .map(|s| s.trim().to_owned())
     }
 
     /// List all stored aliases in this store.

--- a/keriox_sdk/src/store.rs
+++ b/keriox_sdk/src/store.rs
@@ -42,8 +42,8 @@ use crate::{
     controller::Controller,
     error::{Error, Result},
     identifier::Identifier,
-    operations::create_identifier,
-    types::IdentifierConfig,
+    operations::{create_identifier, create_delegated_identifier},
+    types::{DelegationConfig, IdentifierConfig},
 };
 
 /// Manages a directory of named KERI identifiers.
@@ -230,6 +230,105 @@ impl KeriStore {
     pub fn save_registry(&self, alias: &str, registry_id: &IdentifierPrefix) -> Result<()> {
         use keri_core::prefix::CesrPrimitive;
         self.write_file(alias, "reg_id", &registry_id.to_str())
+    }
+
+    /// Create a delegated identifier (delegatee side).
+    ///
+    /// Generates random Ed25519 key pairs, creates a temporary identifier,
+    /// sends a delegation request to the delegator via witnesses, and
+    /// persists all state. The delegated identifier is **not** yet accepted
+    /// — the delegator must approve it first.
+    ///
+    /// After approval, call [`crate::operations::finalize_delegation`] with
+    /// the returned `Identifier` to complete the process.
+    ///
+    /// Returns `(temporary_identifier, delegated_prefix, current_signer)`.
+    ///
+    /// # Errors
+    /// - [`Error::PersistenceError`] on I/O failures.
+    /// - Propagates errors from [`create_delegated_identifier`].
+    pub async fn create_delegated(
+        &self,
+        alias: &str,
+        config: DelegationConfig,
+    ) -> Result<(Identifier, IdentifierPrefix, Arc<Signer>)> {
+        use cesrox::primitives::codes::seed::SeedCode;
+        use rand::rngs::OsRng;
+
+        let current_ed = ed25519_dalek::SigningKey::generate(&mut OsRng);
+        let next_ed = ed25519_dalek::SigningKey::generate(&mut OsRng);
+
+        let current_seed = SeedPrefix::new(
+            SeedCode::RandomSeed256Ed25519,
+            current_ed.as_bytes().to_vec(),
+        );
+        let next_seed = SeedPrefix::new(
+            SeedCode::RandomSeed256Ed25519,
+            next_ed.as_bytes().to_vec(),
+        );
+
+        let alias_dir = self.alias_dir(alias);
+        std::fs::create_dir_all(&alias_dir)
+            .map_err(|e| Error::PersistenceError(format!("cannot create alias dir: {e}")))?;
+
+        let db_path = alias_dir.join("db");
+
+        let signer = Arc::new(
+            Signer::new_with_seed(&current_seed)
+                .map_err(|e| Error::Signing(e.to_string()))?,
+        );
+
+        let (next_pub_key, _) = next_seed
+            .derive_key_pair()
+            .map_err(|e| Error::Signing(e.to_string()))?;
+        let next_pk = keri_controller::BasicPrefix::Ed25519NT(next_pub_key);
+
+        let delegator_id = config.delegator.clone();
+        let (temp_id, delegated_prefix) =
+            create_delegated_identifier(db_path, signer.clone(), next_pk, config).await?;
+
+        // Persist seeds, temporary identifier, delegated prefix, and delegator.
+        use keri_core::prefix::CesrPrimitive;
+        self.write_file(alias, "priv_key", &current_seed.to_str())?;
+        self.write_file(alias, "next_priv_key", &next_seed.to_str())?;
+        self.write_file(alias, "id", &temp_id.id().to_str())?;
+        self.write_file(alias, "delegated_id", &delegated_prefix.to_str())?;
+        self.write_file(alias, "delegator_id", &delegator_id.to_str())?;
+
+        Ok((temp_id, delegated_prefix, signer))
+    }
+
+    /// Persist the delegator identifier for an alias.
+    ///
+    /// # Errors
+    /// - [`Error::PersistenceError`] on I/O failures.
+    pub fn save_delegator(&self, alias: &str, delegator_id: &IdentifierPrefix) -> Result<()> {
+        use keri_core::prefix::CesrPrimitive;
+        self.write_file(alias, "delegator_id", &delegator_id.to_str())
+    }
+
+    /// Load the delegated identifier prefix for an alias.
+    ///
+    /// Returns an error if this alias is not a delegated identifier.
+    ///
+    /// # Errors
+    /// - [`Error::PersistenceError`] if the `delegated_id` file is missing or invalid.
+    pub fn load_delegated_prefix(&self, alias: &str) -> Result<IdentifierPrefix> {
+        let s = self.read_file(alias, "delegated_id")?;
+        IdentifierPrefix::from_str(s.trim())
+            .map_err(|_| Error::PersistenceError("invalid delegated_id".into()))
+    }
+
+    /// Load the delegator identifier prefix for an alias.
+    ///
+    /// Returns an error if this alias is not a delegated identifier.
+    ///
+    /// # Errors
+    /// - [`Error::PersistenceError`] if the `delegator_id` file is missing or invalid.
+    pub fn load_delegator(&self, alias: &str) -> Result<IdentifierPrefix> {
+        let s = self.read_file(alias, "delegator_id")?;
+        IdentifierPrefix::from_str(s.trim())
+            .map_err(|_| Error::PersistenceError("invalid delegator_id".into()))
     }
 
     /// List all stored aliases in this store.

--- a/keriox_sdk/src/store.rs
+++ b/keriox_sdk/src/store.rs
@@ -42,8 +42,8 @@ use crate::{
     controller::Controller,
     error::{Error, Result},
     identifier::Identifier,
-    operations::{create_identifier, create_delegated_identifier, create_group_identifier},
-    types::{DelegationConfig, GroupConfig, IdentifierConfig},
+    operations::{create_identifier, request_delegation, create_multisig},
+    types::{DelegationConfig, IdentifierConfig, MultisigConfig},
 };
 
 /// Manages a directory of named KERI identifiers.
@@ -239,14 +239,14 @@ impl KeriStore {
     /// persists all state. The delegated identifier is **not** yet accepted
     /// — the delegator must approve it first.
     ///
-    /// After approval, call [`crate::operations::finalize_delegation`] with
+    /// After approval, call [`crate::operations::complete_delegation`] with
     /// the returned `Identifier` to complete the process.
     ///
     /// Returns `(temporary_identifier, delegated_prefix, current_signer)`.
     ///
     /// # Errors
     /// - [`Error::PersistenceError`] on I/O failures.
-    /// - Propagates errors from [`create_delegated_identifier`].
+    /// - Propagates errors from [`request_delegation`].
     pub async fn create_delegated(
         &self,
         alias: &str,
@@ -285,7 +285,7 @@ impl KeriStore {
 
         let delegator_id = config.delegator.clone();
         let (temp_id, delegated_prefix) =
-            create_delegated_identifier(db_path, signer.clone(), next_pk, config).await?;
+            request_delegation(db_path, signer.clone(), next_pk, config).await?;
 
         // Persist seeds, temporary identifier, delegated prefix, and delegator.
         use keri_core::prefix::CesrPrimitive;
@@ -331,98 +331,73 @@ impl KeriStore {
             .map_err(|_| Error::PersistenceError("invalid delegator_id".into()))
     }
 
+    // ── Multisig group methods (preferred names) ──────────────────────────────
+
     /// Create a multisig group identifier and persist metadata (initiator side).
     ///
     /// The caller's individual identifier must already exist under
     /// `member_alias`. This method creates a new alias directory for the
-    /// group that stores the group prefix, participant list, and a back-
-    /// reference to the member alias.
+    /// group that stores the group prefix, member list, and a back-reference
+    /// to the member alias.
     ///
     /// Other participants must still co-sign via
-    /// [`crate::operations::join_group`], and all participants must call
-    /// [`crate::operations::collect_group_signatures`] to finalise.
+    /// [`crate::operations::accept_multisig`], and all participants must call
+    /// [`crate::operations::sync_multisig`] to finalise.
     ///
     /// Returns the group `IdentifierPrefix`.
     ///
     /// # Errors
     /// - [`Error::PersistenceError`] on I/O failures.
-    /// - Propagates errors from [`create_group_identifier`].
-    pub async fn create_group(
+    /// - Propagates errors from [`create_multisig`].
+    pub async fn create_multisig_group(
         &self,
         group_alias: &str,
         member_alias: &str,
-        config: GroupConfig,
+        config: MultisigConfig,
     ) -> Result<IdentifierPrefix> {
         let mut id = self.load(member_alias)?;
         let signer = self.load_signer(member_alias)?;
 
-        let participants = config.participants.clone();
-        let group_prefix = create_group_identifier(&mut id, &signer, config).await?;
+        let members = config.members.clone();
+        let group_prefix = create_multisig(&mut id, &signer, config).await?;
 
-        // Persist group metadata under the group alias.
-        let alias_dir = self.alias_dir(group_alias);
-        std::fs::create_dir_all(&alias_dir)
-            .map_err(|e| Error::PersistenceError(format!("cannot create alias dir: {e}")))?;
-
-        use keri_core::prefix::CesrPrimitive;
-        self.write_file(group_alias, "group_id", &group_prefix.to_str())?;
-        self.write_file(group_alias, "member_alias", member_alias)?;
-
-        let participant_strs: Vec<String> =
-            participants.iter().map(|p| p.to_str()).collect();
-        let json = serde_json::to_string(&participant_strs)
-            .map_err(|e| Error::PersistenceError(format!("cannot serialise participants: {e}")))?;
-        self.write_file(group_alias, "participants", &json)?;
+        self.persist_group_metadata(group_alias, &group_prefix, &members, member_alias)?;
 
         Ok(group_prefix)
     }
 
-    /// Persist group metadata after joining a group (joiner side).
+    /// Persist multisig group metadata after joining (joiner side).
     ///
-    /// Call this after [`crate::operations::join_group`] to record the group
-    /// prefix, participant list, and member alias for later retrieval.
+    /// Call this after [`crate::operations::accept_multisig`] to record the
+    /// group prefix, member list, and member alias for later retrieval.
     ///
     /// # Errors
     /// - [`Error::PersistenceError`] on I/O failures.
-    pub fn save_group(
+    pub fn save_multisig(
         &self,
         group_alias: &str,
         group_id: &IdentifierPrefix,
-        participants: &[IdentifierPrefix],
+        members: &[IdentifierPrefix],
         member_alias: &str,
     ) -> Result<()> {
-        let alias_dir = self.alias_dir(group_alias);
-        std::fs::create_dir_all(&alias_dir)
-            .map_err(|e| Error::PersistenceError(format!("cannot create alias dir: {e}")))?;
-
-        use keri_core::prefix::CesrPrimitive;
-        self.write_file(group_alias, "group_id", &group_id.to_str())?;
-        self.write_file(group_alias, "member_alias", member_alias)?;
-
-        let participant_strs: Vec<String> =
-            participants.iter().map(|p| p.to_str()).collect();
-        let json = serde_json::to_string(&participant_strs)
-            .map_err(|e| Error::PersistenceError(format!("cannot serialise participants: {e}")))?;
-        self.write_file(group_alias, "participants", &json)?;
-
-        Ok(())
+        self.persist_group_metadata(group_alias, group_id, members, member_alias)
     }
 
-    /// Load the group identifier prefix for an alias.
+    /// Load the multisig group identifier prefix for an alias.
     ///
     /// # Errors
     /// - [`Error::PersistenceError`] if the `group_id` file is missing or invalid.
-    pub fn load_group_prefix(&self, alias: &str) -> Result<IdentifierPrefix> {
+    pub fn load_multisig_prefix(&self, alias: &str) -> Result<IdentifierPrefix> {
         let s = self.read_file(alias, "group_id")?;
         IdentifierPrefix::from_str(s.trim())
             .map_err(|_| Error::PersistenceError("invalid group_id".into()))
     }
 
-    /// Load the participant list for a group alias.
+    /// Load the member list for a multisig group alias.
     ///
     /// # Errors
     /// - [`Error::PersistenceError`] if the `participants` file is missing or invalid.
-    pub fn load_group_participants(&self, alias: &str) -> Result<Vec<IdentifierPrefix>> {
+    pub fn load_multisig_members(&self, alias: &str) -> Result<Vec<IdentifierPrefix>> {
         let json = self.read_file(alias, "participants")?;
         let strs: Vec<String> = serde_json::from_str(&json)
             .map_err(|e| Error::PersistenceError(format!("invalid participants JSON: {e}")))?;
@@ -434,12 +409,12 @@ impl KeriStore {
             .collect()
     }
 
-    /// Load the member alias for a group alias (back-reference to the
+    /// Load the member alias for a multisig group (back-reference to the
     /// individual identifier used by this participant).
     ///
     /// # Errors
     /// - [`Error::PersistenceError`] if the `member_alias` file is missing.
-    pub fn load_group_member_alias(&self, alias: &str) -> Result<String> {
+    pub fn load_multisig_member_alias(&self, alias: &str) -> Result<String> {
         self.read_file(alias, "member_alias")
             .map(|s| s.trim().to_owned())
     }
@@ -466,6 +441,29 @@ impl KeriStore {
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────
+
+    fn persist_group_metadata(
+        &self,
+        group_alias: &str,
+        group_id: &IdentifierPrefix,
+        members: &[IdentifierPrefix],
+        member_alias: &str,
+    ) -> Result<()> {
+        let alias_dir = self.alias_dir(group_alias);
+        std::fs::create_dir_all(&alias_dir)
+            .map_err(|e| Error::PersistenceError(format!("cannot create alias dir: {e}")))?;
+
+        use keri_core::prefix::CesrPrimitive;
+        self.write_file(group_alias, "group_id", &group_id.to_str())?;
+        self.write_file(group_alias, "member_alias", member_alias)?;
+
+        let member_strs: Vec<String> = members.iter().map(|p| p.to_str()).collect();
+        let json = serde_json::to_string(&member_strs)
+            .map_err(|e| Error::PersistenceError(format!("cannot serialise members: {e}")))?;
+        self.write_file(group_alias, "participants", &json)?;
+
+        Ok(())
+    }
 
     fn alias_dir(&self, alias: &str) -> PathBuf {
         self.root.join(alias)

--- a/keriox_sdk/src/tel.rs
+++ b/keriox_sdk/src/tel.rs
@@ -8,7 +8,7 @@
 //! creating a registry see [`crate::operations::incept_registry`].
 
 use keri_controller::IdentifierPrefix;
-use keri_core::{actor::prelude::SelfAddressingIdentifier, signer::Signer};
+use keri_core::actor::prelude::SelfAddressingIdentifier;
 use teliox::state::vc_state::TelState;
 
 use crate::{
@@ -29,17 +29,15 @@ use crate::{
 /// - [`Error::RegistryNotIncepted`] if `registry_id` is not known locally.
 /// - [`Error::Mechanics`] on network or processing failures.
 /// - [`Error::Signing`] if signing the query fails.
-pub async fn check_credential_status(
+pub async fn check_credential_status<S: crate::operations::SigningBackend>(
     id: &Identifier,
-    signer: &Signer,
+    signer: &S,
     registry_id: &IdentifierPrefix,
     credential_said: &SelfAddressingIdentifier,
 ) -> Result<CredentialStatus> {
-    // Make sure the registry is known.
     id.find_management_tel_state(registry_id)?
         .ok_or_else(|| Error::RegistryNotIncepted(registry_id.clone()))?;
 
-    // Build a VC identifier from the credential SAID.
     let vc_id = IdentifierPrefix::self_addressing(credential_said.clone());
 
     let qry = id.query_tel(registry_id.clone(), vc_id)?;

--- a/keriox_sdk/src/types.rs
+++ b/keriox_sdk/src/types.rs
@@ -88,6 +88,58 @@ impl TryFrom<keri_controller::mailbox_updating::ActionRequired> for DelegationRe
     }
 }
 
+// ── Multisig config ──────────────────────────────────────────────────────────
+
+/// Configuration for creating a multisig group identifier.
+///
+/// Used by [`crate::operations::create_group_identifier`] and
+/// [`crate::store::KeriStore::create_group`].
+#[derive(Debug, Clone)]
+pub struct GroupConfig {
+    /// Other participants' identifier prefixes (not including the caller).
+    pub participants: Vec<IdentifierPrefix>,
+    /// Number of signatures required to authorise a group event.
+    pub signature_threshold: u64,
+    /// Number of next-key commitments required (defaults to `signature_threshold` if `None`).
+    pub next_keys_threshold: Option<u64>,
+    /// Witness OOBIs for the group identifier.
+    pub witnesses: Vec<LocationScheme>,
+    /// Witness signing threshold.
+    pub witness_threshold: u64,
+    /// Optional delegator (for a delegated group identifier).
+    pub delegator: Option<IdentifierPrefix>,
+}
+
+/// A pending multisig request discovered in the mailbox.
+///
+/// Extracted from [`ActionRequired::MultisigRequest`] via [`MultisigRequest::try_from`].
+/// Pass this to [`crate::operations::join_group`] to co-sign the event.
+#[derive(Debug)]
+pub struct MultisigRequest {
+    /// The group key event (ICP/ROT/IXN) to be co-signed.
+    pub event: keri_core::event_message::msg::KeriEvent<keri_core::event::KeyEvent>,
+    /// The exchange message to forward after signing.
+    pub exchange: keri_core::mailbox::exchange::ExchangeMessage,
+}
+
+impl TryFrom<keri_controller::mailbox_updating::ActionRequired> for MultisigRequest {
+    type Error = keri_controller::mailbox_updating::ActionRequired;
+
+    fn try_from(
+        action: keri_controller::mailbox_updating::ActionRequired,
+    ) -> std::result::Result<Self, Self::Error> {
+        match action {
+            keri_controller::mailbox_updating::ActionRequired::MultisigRequest(ev, exn) => {
+                Ok(MultisigRequest {
+                    event: ev,
+                    exchange: exn,
+                })
+            }
+            other => Err(other),
+        }
+    }
+}
+
 // ── Signing / verification result types ──────────────────────────────────────
 
 /// A CESR-encoded signed payload ready for transport.

--- a/keriox_sdk/src/types.rs
+++ b/keriox_sdk/src/types.rs
@@ -40,6 +40,54 @@ pub struct RotationConfig {
     pub witness_threshold: u64,
 }
 
+// ── Delegation config ────────────────────────────────────────────────────────
+
+/// Configuration for creating a delegated identifier (delegatee side).
+///
+/// Used by [`crate::operations::create_delegated_identifier`] and
+/// [`crate::store::KeriStore::create_delegated`].
+#[derive(Debug, Clone)]
+pub struct DelegationConfig {
+    /// The delegator's identifier prefix.
+    pub delegator: IdentifierPrefix,
+    /// Witness OOBIs for the delegated identifier.
+    pub witnesses: Vec<LocationScheme>,
+    /// Witness signing threshold.
+    pub witness_threshold: u64,
+    /// Watcher OOBIs to configure after delegation is accepted.
+    pub watchers: Vec<LocationScheme>,
+}
+
+/// A pending delegation request discovered by the delegator.
+///
+/// Extracted from [`ActionRequired::DelegationRequest`] via [`DelegationRequest::try_from`].
+/// Pass this to [`crate::operations::approve_delegation`] to approve.
+#[derive(Debug)]
+pub struct DelegationRequest {
+    /// The delegating IXN event to be signed by the delegator.
+    pub delegating_event: keri_core::event_message::msg::KeriEvent<keri_core::event::KeyEvent>,
+    /// The exchange message to forward to the delegatee after approval.
+    pub exchange: keri_core::mailbox::exchange::ExchangeMessage,
+}
+
+impl TryFrom<keri_controller::mailbox_updating::ActionRequired> for DelegationRequest {
+    type Error = keri_controller::mailbox_updating::ActionRequired;
+
+    fn try_from(
+        action: keri_controller::mailbox_updating::ActionRequired,
+    ) -> std::result::Result<Self, Self::Error> {
+        match action {
+            keri_controller::mailbox_updating::ActionRequired::DelegationRequest(ev, exn) => {
+                Ok(DelegationRequest {
+                    delegating_event: ev,
+                    exchange: exn,
+                })
+            }
+            other => Err(other),
+        }
+    }
+}
+
 // ── Signing / verification result types ──────────────────────────────────────
 
 /// A CESR-encoded signed payload ready for transport.

--- a/keriox_sdk/src/types.rs
+++ b/keriox_sdk/src/types.rs
@@ -73,6 +73,14 @@ impl DelegationRequest {
     pub fn identifier(&self) -> IdentifierPrefix {
         self.delegating_event.data.get_prefix()
     }
+
+    /// Consume and return the underlying `ActionRequired` for low-level storage.
+    pub fn into_action_required(self) -> keri_controller::mailbox_updating::ActionRequired {
+        keri_controller::mailbox_updating::ActionRequired::DelegationRequest(
+            self.delegating_event,
+            self.exchange,
+        )
+    }
 }
 
 impl TryFrom<keri_controller::mailbox_updating::ActionRequired> for DelegationRequest {
@@ -127,6 +135,14 @@ impl MultisigRequest {
     /// The group identifier prefix this request is for.
     pub fn group_prefix(&self) -> IdentifierPrefix {
         self.event.data.get_prefix()
+    }
+
+    /// Consume and return the underlying `ActionRequired` for low-level storage.
+    pub fn into_action_required(self) -> keri_controller::mailbox_updating::ActionRequired {
+        keri_controller::mailbox_updating::ActionRequired::MultisigRequest(
+            self.event,
+            self.exchange,
+        )
     }
 }
 
@@ -188,6 +204,14 @@ impl PendingRequest {
         match self {
             Self::Multisig(r) => Some(r),
             _ => None,
+        }
+    }
+
+    /// Consume and return the underlying `ActionRequired` for low-level storage.
+    pub fn into_action_required(self) -> keri_controller::mailbox_updating::ActionRequired {
+        match self {
+            Self::Delegation(r) => r.into_action_required(),
+            Self::Multisig(r) => r.into_action_required(),
         }
     }
 }

--- a/keriox_sdk/src/types.rs
+++ b/keriox_sdk/src/types.rs
@@ -44,7 +44,7 @@ pub struct RotationConfig {
 
 /// Configuration for creating a delegated identifier (delegatee side).
 ///
-/// Used by [`crate::operations::create_delegated_identifier`] and
+/// Used by [`crate::operations::request_delegation`] and
 /// [`crate::store::KeriStore::create_delegated`].
 #[derive(Debug, Clone)]
 pub struct DelegationConfig {
@@ -64,10 +64,15 @@ pub struct DelegationConfig {
 /// Pass this to [`crate::operations::approve_delegation`] to approve.
 #[derive(Debug)]
 pub struct DelegationRequest {
-    /// The delegating IXN event to be signed by the delegator.
-    pub delegating_event: keri_core::event_message::msg::KeriEvent<keri_core::event::KeyEvent>,
-    /// The exchange message to forward to the delegatee after approval.
-    pub exchange: keri_core::mailbox::exchange::ExchangeMessage,
+    pub(crate) delegating_event: keri_core::event_message::msg::KeriEvent<keri_core::event::KeyEvent>,
+    pub(crate) exchange: keri_core::mailbox::exchange::ExchangeMessage,
+}
+
+impl DelegationRequest {
+    /// The identifier prefix of the delegatee requesting delegation.
+    pub fn identifier(&self) -> IdentifierPrefix {
+        self.delegating_event.data.get_prefix()
+    }
 }
 
 impl TryFrom<keri_controller::mailbox_updating::ActionRequired> for DelegationRequest {
@@ -90,36 +95,39 @@ impl TryFrom<keri_controller::mailbox_updating::ActionRequired> for DelegationRe
 
 // ── Multisig config ──────────────────────────────────────────────────────────
 
-/// Configuration for creating a multisig group identifier.
+/// Configuration for creating a multisig identifier.
 ///
-/// Used by [`crate::operations::create_group_identifier`] and
-/// [`crate::store::KeriStore::create_group`].
+/// Used by [`crate::operations::create_multisig`] and
+/// [`crate::store::KeriStore::create_multisig_group`].
 #[derive(Debug, Clone)]
-pub struct GroupConfig {
-    /// Other participants' identifier prefixes (not including the caller).
-    pub participants: Vec<IdentifierPrefix>,
+pub struct MultisigConfig {
+    /// Other members' identifier prefixes (not including the caller).
+    pub members: Vec<IdentifierPrefix>,
     /// Number of signatures required to authorise a group event.
-    pub signature_threshold: u64,
-    /// Number of next-key commitments required (defaults to `signature_threshold` if `None`).
-    pub next_keys_threshold: Option<u64>,
-    /// Witness OOBIs for the group identifier.
+    pub threshold: u64,
+    /// Witness OOBIs for the multisig identifier.
     pub witnesses: Vec<LocationScheme>,
     /// Witness signing threshold.
     pub witness_threshold: u64,
-    /// Optional delegator (for a delegated group identifier).
+    /// Optional delegator (for a delegated multisig identifier).
     pub delegator: Option<IdentifierPrefix>,
 }
 
 /// A pending multisig request discovered in the mailbox.
 ///
 /// Extracted from [`ActionRequired::MultisigRequest`] via [`MultisigRequest::try_from`].
-/// Pass this to [`crate::operations::join_group`] to co-sign the event.
+/// Pass this to [`crate::operations::accept_multisig`] to co-sign the event.
 #[derive(Debug)]
 pub struct MultisigRequest {
-    /// The group key event (ICP/ROT/IXN) to be co-signed.
-    pub event: keri_core::event_message::msg::KeriEvent<keri_core::event::KeyEvent>,
-    /// The exchange message to forward after signing.
-    pub exchange: keri_core::mailbox::exchange::ExchangeMessage,
+    pub(crate) event: keri_core::event_message::msg::KeriEvent<keri_core::event::KeyEvent>,
+    pub(crate) exchange: keri_core::mailbox::exchange::ExchangeMessage,
+}
+
+impl MultisigRequest {
+    /// The group identifier prefix this request is for.
+    pub fn group_prefix(&self) -> IdentifierPrefix {
+        self.event.data.get_prefix()
+    }
 }
 
 impl TryFrom<keri_controller::mailbox_updating::ActionRequired> for MultisigRequest {
@@ -136,6 +144,73 @@ impl TryFrom<keri_controller::mailbox_updating::ActionRequired> for MultisigRequ
                 })
             }
             other => Err(other),
+        }
+    }
+}
+
+// ── Unified pending request ──────────────────────────────────────────────────
+
+/// A pending request discovered in the mailbox.
+///
+/// Returned by [`crate::operations::poll_pending_requests`]. Use the
+/// convenience methods or pattern-match to determine the request type
+/// and pass it to [`crate::operations::approve_delegation`] or
+/// [`crate::operations::accept_multisig`] accordingly.
+#[derive(Debug)]
+pub enum PendingRequest {
+    /// A delegation request from a delegatee awaiting approval.
+    Delegation(DelegationRequest),
+    /// A multisig event from another participant awaiting co-signature.
+    Multisig(MultisigRequest),
+}
+
+impl PendingRequest {
+    /// Returns `true` if this is a delegation request.
+    pub fn is_delegation(&self) -> bool {
+        matches!(self, Self::Delegation(_))
+    }
+
+    /// Returns `true` if this is a multisig request.
+    pub fn is_multisig(&self) -> bool {
+        matches!(self, Self::Multisig(_))
+    }
+
+    /// Consume and return the inner delegation request, if any.
+    pub fn into_delegation(self) -> Option<DelegationRequest> {
+        match self {
+            Self::Delegation(r) => Some(r),
+            _ => None,
+        }
+    }
+
+    /// Consume and return the inner multisig request, if any.
+    pub fn into_multisig(self) -> Option<MultisigRequest> {
+        match self {
+            Self::Multisig(r) => Some(r),
+            _ => None,
+        }
+    }
+}
+
+impl TryFrom<keri_controller::mailbox_updating::ActionRequired> for PendingRequest {
+    type Error = keri_controller::mailbox_updating::ActionRequired;
+
+    fn try_from(
+        action: keri_controller::mailbox_updating::ActionRequired,
+    ) -> std::result::Result<Self, Self::Error> {
+        match action {
+            keri_controller::mailbox_updating::ActionRequired::DelegationRequest(ev, exn) => {
+                Ok(PendingRequest::Delegation(DelegationRequest {
+                    delegating_event: ev,
+                    exchange: exn,
+                }))
+            }
+            keri_controller::mailbox_updating::ActionRequired::MultisigRequest(ev, exn) => {
+                Ok(PendingRequest::Multisig(MultisigRequest {
+                    event: ev,
+                    exchange: exn,
+                }))
+            }
         }
     }
 }


### PR DESCRIPTION
Add standalone keri_keyprovider crate with pluggable signing backends:
  - Software: in-memory Ed25519/secp256k1 keys
  - File-encrypted: Argon2id + XChaCha20-Poly1305 encrypted key files
  - OS-keychain: platform-native credential store (macOS/Windows/Linux)

Introduce SigningBackend trait in keriox_sdk that abstracts the signing interface, allowing Arc<Signer> or Arc<dyn KeyProvider> interchangeably. Refactor operations.rs, signing.rs, and tel.rs to use the generic trait, preserving full backward compatibility with existing Arc<Signer> callers